### PR TITLE
MAT-3536: issue while reseting the cql when newly created measure doesn't have CQL

### DIFF
--- a/src/components/measureEditor/MeasureEditor.test.tsx
+++ b/src/components/measureEditor/MeasureEditor.test.tsx
@@ -23,7 +23,7 @@ const serviceConfig: ServiceConfig = {
   },
 };
 
-const renderEditor = () => {
+const renderEditor = (measure: Measure) => {
   const { getByTestId } = render(
     <ApiContextProvider value={serviceConfig}>
       <MeasureContextProvider value={{ measure, setMeasure }}>
@@ -41,16 +41,28 @@ describe("MeasureEditor component", () => {
   });
 
   it("should mount measure editor component with measure cql", async () => {
-    const getByTestId = renderEditor();
+    const getByTestId = renderEditor(measure);
     const editorContainer = (await getByTestId(
       "measure-editor"
     )) as HTMLInputElement;
     expect(measure.cql).toEqual(editorContainer.value);
   });
 
+  it("set the editor to empty when no measure cql present", async () => {
+    const measureWithNoCql = {
+      id: "MSR1",
+      measureName: "MSR1",
+    } as Measure;
+    const getByTestId = renderEditor(measureWithNoCql);
+    const editorContainer = (await getByTestId(
+      "measure-editor"
+    )) as HTMLInputElement;
+    expect(editorContainer.value).toEqual("");
+  });
+
   it("save measure with updated cql in editor on save button click", async () => {
     mockedAxios.put.mockResolvedValue({ data: measure });
-    const getByTestId = renderEditor();
+    const getByTestId = renderEditor(measure);
     const editorContainer = (await getByTestId(
       "measure-editor"
     )) as HTMLInputElement;
@@ -60,31 +72,54 @@ describe("MeasureEditor component", () => {
         value: "library testCql version '2.0.000'",
       },
     });
-    fireEvent.click(getByTestId("save_cql_btn"));
+    fireEvent.click(getByTestId("save-cql-btn"));
     await waitFor(() => {
+      const successMessage = getByTestId("save-cql-success");
+      expect(successMessage.textContent).toEqual("CQL saved successfully");
       expect(mockedAxios.put).toHaveBeenCalledTimes(1);
       expect(setMeasure).toHaveBeenCalledTimes(1);
     });
   });
 
   it("reset the editor changes with measure cql when clicked on cancel button", async () => {
-    mockedAxios.put.mockResolvedValue({ data: measure });
-    const getByTestId = renderEditor();
+    const getByTestId = renderEditor(measure);
     const editorContainer = (await getByTestId(
       "measure-editor"
     )) as HTMLInputElement;
     expect(measure.cql).toEqual(editorContainer.value);
+    // set new value to editor
     fireEvent.change(getByTestId("measure-editor"), {
       target: {
         value: "library testCql version '2.0.000'",
       },
     });
-    fireEvent.click(getByTestId("reset_cql_btn"));
-    // no save callbacks should be executed
+    // click on cancel button
+    fireEvent.click(getByTestId("reset-cql-btn"));
     await waitFor(() => {
+      // check for old value
       expect(measure.cql).toEqual(editorContainer.value);
-      expect(mockedAxios.put).toHaveBeenCalledTimes(0);
-      expect(setMeasure).toHaveBeenCalledTimes(0);
+    });
+  });
+
+  it("reports an error when save cql fails", async () => {
+    // mock put call for errors
+    mockedAxios.put.mockRejectedValue("server error");
+    const getByTestId = renderEditor(measure);
+    const editorContainer = (await getByTestId(
+      "measure-editor"
+    )) as HTMLInputElement;
+    expect(measure.cql).toEqual(editorContainer.value);
+    // set new value to editor
+    fireEvent.change(getByTestId("measure-editor"), {
+      target: {
+        value: "test cql",
+      },
+    });
+    // click on save button
+    fireEvent.click(getByTestId("save-cql-btn"));
+    await waitFor(() => {
+      const error = getByTestId("save-cql-error");
+      expect(error.textContent).toEqual("Error updating the CQL");
     });
   });
 });

--- a/src/components/measureEditor/MeasureEditor.tsx
+++ b/src/components/measureEditor/MeasureEditor.tsx
@@ -15,7 +15,7 @@ const EditorActions = tw.div`mt-2 ml-2 mb-5`;
 const MeasureEditor = () => {
   const { measure, setMeasure } = useCurrentMeasure();
   const [editorVal, setEditorVal]: [string, Dispatch<SetStateAction<string>>] =
-    useState(measure.cql);
+    useState(measure.cql || "");
   const measureServiceApi = useMeasureServiceApi();
   const [success, setSuccess] = useState(false);
   const [error, setError] = useState(false);
@@ -31,7 +31,6 @@ const MeasureEditor = () => {
         .catch((reason) => {
           console.error(reason);
           setError(true);
-          throw new Error(reason.message);
         });
     }
   };
@@ -43,7 +42,7 @@ const MeasureEditor = () => {
   };
 
   const resetCql = (): void => {
-    setEditorVal(measure.cql);
+    setEditorVal(measure.cql || "");
   };
 
   const editorProps = {
@@ -55,16 +54,24 @@ const MeasureEditor = () => {
     <>
       <MadieEditor {...editorProps} />
       <EditorActions data-testid="measure-editor-actions">
-        <UpdateAlerts data-testid="update_cql_alerts">
-          {success && <SuccessText>CQL saved successfully</SuccessText>}
-          {error && <ErrorText>Error updating the CQL</ErrorText>}
+        <UpdateAlerts data-testid="update-cql-alerts">
+          {success && (
+            <SuccessText data-testid="save-cql-success">
+              CQL saved successfully
+            </SuccessText>
+          )}
+          {error && (
+            <ErrorText data-testid="save-cql-error">
+              Error updating the CQL
+            </ErrorText>
+          )}
         </UpdateAlerts>
         <Button
           buttonSize="md"
           buttonTitle="Save"
           variant="primary"
           onClick={() => updateMeasureCql()}
-          data-testid="save_cql_btn"
+          data-testid="save-cql-btn"
         />
         <Button
           tw="ml-2"
@@ -72,7 +79,7 @@ const MeasureEditor = () => {
           buttonTitle="Cancel"
           variant="secondary"
           onClick={() => resetCql()}
-          data-testid="reset_cql_btn"
+          data-testid="reset-cql-btn"
         />
       </EditorActions>
     </>


### PR DESCRIPTION


## MADiE PR

Jira Ticket: [MAT-3536](https://jira.cms.gov/browse/MAT-3536)
(Optional) Related Tickets:

### Summary
**The original ticket was implemented and merged already. This is a Bugfix for a bug reported by QA.** 
**Issue**: When the newly created measure doesn't have CQL in it, the editor gets initialized with null as measure cql will be null. In this case, the save/cancel button doesn't work.
**Fix**: Initialize the editor with an empty string.   

### All Submissions
* [x] This PR has the JIRA linked.
* [x] Required tests are included.
* [x] No extemporaneous files are included (i.e Complied files or testing results).
* [x] This PR is merging into the **correct branch**.
* [x] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [x] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).
* [x] All CDN/Web dependancies are hosted internally (i.e MADiE-Root Repo).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
