### PR TITLE
MAT-3520: added data test id to lib name display

### DIFF
--- a/src/components/editMeasure/measureDetails/measureInformation/MeasureInformation.tsx
+++ b/src/components/editMeasure/measureDetails/measureInformation/MeasureInformation.tsx
@@ -46,7 +46,7 @@ export default function MeasureInformation() {
         <span tw="mr-2">Measure Name:</span>
         <InlineEdit text={measure.measureName} onSetText={updateMeasureTitle} />
       </div>
-      <div tw="flex">
+      <div tw="flex" data-testid="cql-library-name-display">
         <span tw="mr-2">Measure CQL Library Name:</span>
         <span>{measure.cqlLibraryName || "NA"}</span>
       </div>

--- a/src/components/editMeasure/measureDetails/measureInformation/__snapshots__/MeasureInformation.test.tsx.snap
+++ b/src/components/editMeasure/measureDetails/measureInformation/__snapshots__/MeasureInformation.test.tsx.snap
@@ -40,6 +40,7 @@ exports[`MeasureInformation component should render the component with a blank m
   </div>
   <div
     class="MeasureInformation___StyledDiv4-sc-1pua5bc-5 kmMvDE"
+    data-testid="cql-library-name-display"
   >
     <span
       class="MeasureInformation___StyledSpan3-sc-1pua5bc-6 cPwLxs"
@@ -94,6 +95,7 @@ exports[`MeasureInformation component should render the component with measure's
   </div>
   <div
     class="MeasureInformation___StyledDiv4-sc-1pua5bc-5 kmMvDE"
+    data-testid="cql-library-name-display"
   >
     <span
       class="MeasureInformation___StyledSpan3-sc-1pua5bc-6 cPwLxs"


### PR DESCRIPTION
## MADiE PR

Jira Ticket: [MAT-3520](https://jira.cms.gov/browse/MAT-3520): Save Measure Library Name on Measure Creation
(Optional) Related Tickets:

### Summary
- Added data test ids for cypress testing 

### All Submissions
* [x] This PR has the JIRA linked.
* [x] Required tests are included.
* [x] No extemporaneous files are included (i.e Complied files or testing results).
* [x] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).
* [ ] All CDN/Web dependancies are hosted internally (i.e MADiE-Root Repo).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
