### PR TITLE
[MAT-3798] Display in-line Error on Measure Scoring field & Remove None Selection

### DIFF
--- a/src/components/createNewMeasure/CreateNewMeasure.test.tsx
+++ b/src/components/createNewMeasure/CreateNewMeasure.test.tsx
@@ -4,7 +4,6 @@ import {
   render,
   screen,
   waitFor,
-  waitForElementToBeRemoved,
   within,
 } from "@testing-library/react";
 import { CreateNewMeasure } from "./CreateNewMeasure";
@@ -106,8 +105,6 @@ describe("Home component", () => {
       name: /select a model/i,
     });
     userEvent.click(modelDropdown);
-    const noneOption = await screen.findByText("None");
-    expect(noneOption).toBeInTheDocument();
     const qiCoreOption = screen.getByText("QI-Core");
     expect(qiCoreOption).toBeInTheDocument();
   });
@@ -133,9 +130,9 @@ describe("Home component", () => {
       name: /select a model/i,
     });
     const options = within(modelOptionsList).getAllByRole("option");
-    expect(options.length).toBe(Object.values(Model).length + 1);
+    expect(options.length).toBe(Object.values(Model).length);
     const optionTexts = options.map((option) => option.textContent);
-    expect(optionTexts).toEqual(["None", ...Object.values(Model)]);
+    expect(optionTexts).toEqual([...Object.values(Model)]);
   });
 
   it("should have measure scoring options of Measure Scoring enum types plus None", async () => {
@@ -148,9 +145,9 @@ describe("Home component", () => {
       name: /select scoring/i,
     });
     const options = within(measureScoringOptionsList).getAllByRole("option");
-    expect(options.length).toBe(Object.values(MeasureScoring).length + 1);
+    expect(options.length).toBe(Object.values(MeasureScoring).length);
     const optionTexts = options.map((option) => option.textContent);
-    expect(optionTexts).toEqual(["None", ...Object.values(MeasureScoring)]);
+    expect(optionTexts).toEqual([...Object.values(MeasureScoring)]);
   });
 
   it("should update the dropdown with the selected option", async () => {
@@ -162,7 +159,6 @@ describe("Home component", () => {
     const qiCoreOption = screen.getByText("QI-Core");
     expect(qiCoreOption).toBeInTheDocument();
     userEvent.click(qiCoreOption);
-    await waitForElementToBeRemoved(() => screen.queryByText("None"));
     const qiCore = await screen.findByText("QI-Core");
     expect(qiCore).toBeInTheDocument();
     const qiCoreButton = screen.getByRole("button", { name: /qi-core/i });
@@ -191,7 +187,6 @@ describe("Home component", () => {
     userEvent.click(modelDropdown);
     const qiCoreOption = await screen.findByText(measure.model);
     userEvent.click(qiCoreOption);
-    await waitForElementToBeRemoved(() => screen.queryByText("None"));
 
     const measureScoringDropdown = screen.getByRole("button", {
       name: /select scoring/i,
@@ -199,7 +194,6 @@ describe("Home component", () => {
     userEvent.click(measureScoringDropdown);
     const cohortOption = await screen.findByText(measure.measureScoring);
     userEvent.click(cohortOption);
-    await waitForElementToBeRemoved(() => screen.queryByText("None"));
 
     const cqlLibraryNameInput = screen.getByRole("textbox", {
       name: "Measure CQL Library Name",
@@ -242,7 +236,6 @@ describe("Home component", () => {
     userEvent.click(modelDropdown);
     const qiCoreOption = await screen.findByText("QI-Core");
     userEvent.click(qiCoreOption);
-    await waitForElementToBeRemoved(() => screen.queryByText("None"));
 
     const scoringDropdown = screen.getByRole("button", {
       name: /select scoring/i,
@@ -250,7 +243,6 @@ describe("Home component", () => {
     userEvent.click(scoringDropdown);
     const cohortOption = await screen.findByText("Cohort");
     userEvent.click(cohortOption);
-    await waitForElementToBeRemoved(() => screen.queryByText("None"));
 
     const cqlLibraryNameInput = screen.getByRole("textbox", {
       name: "Measure CQL Library Name",

--- a/src/components/createNewMeasure/CreateNewMeasure.tsx
+++ b/src/components/createNewMeasure/CreateNewMeasure.tsx
@@ -144,6 +144,13 @@ const CreateNewMeasure = () => {
               {...formik.getFieldProps("measureScoring")}
               data-testid="measure-scoring-select-field"
               name={"measureScoring"}
+              error={
+                formik.touched.measureScoring &&
+                Boolean(formik.errors.measureScoring)
+              }
+              helperText={
+                formik.touched.measureScoring && formik.errors.measureScoring
+              }
             >
               <MenuItem
                 key=""

--- a/src/components/createNewMeasure/CreateNewMeasure.tsx
+++ b/src/components/createNewMeasure/CreateNewMeasure.tsx
@@ -103,9 +103,6 @@ const CreateNewMeasure = () => {
               error={formik.touched.model && Boolean(formik.errors.model)}
               helperText={formik.touched.model && formik.errors.model}
             >
-              <MenuItem key="" value="" data-testid="measure-model-option-none">
-                None
-              </MenuItem>
               {Object.keys(Model).map((modelKey) => {
                 return (
                   <MenuItem
@@ -152,13 +149,6 @@ const CreateNewMeasure = () => {
                 formik.touched.measureScoring && formik.errors.measureScoring
               }
             >
-              <MenuItem
-                key=""
-                value=""
-                data-testid="measure-scoring-option-none"
-              >
-                None
-              </MenuItem>
               {Object.keys(MeasureScoring).map((scoringKey) => {
                 return (
                   <MenuItem


### PR DESCRIPTION
## MADiE PR

Jira Ticket: [MAT-3798](https://jira.cms.gov/browse/MAT-3798)
(Optional) Related Tickets:

### Summary
- Display in-line error message when entry is invalid on blur
- Remove None selection option from Measure Model and Scoring

#### In-line validation error
![Screen Shot 2022-01-12 at 11 22 10 AM](https://user-images.githubusercontent.com/56264529/149180251-1d1c882c-c5af-4a53-9450-3cc7d903583f.png)

#### Remove "None" options
![Screen Shot 2022-01-12 at 11 22 40 AM](https://user-images.githubusercontent.com/56264529/149180225-895bc17b-53e1-4bf3-b05b-420df62b6514.png)
![Screen Shot 2022-01-12 at 11 22 50 AM](https://user-images.githubusercontent.com/56264529/149180236-7af45a7c-2df4-4929-9df9-4baefe2fb29f.png)


### All Submissions
* [x] This PR has the JIRA linked.
* [x] Required tests are included.
* [x] No extemporaneous files are included (i.e Complied files or testing results).
* [x] This PR is merging into the **correct branch**.
* [x] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [x] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [x] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).
* [x] All CDN/Web dependancies are hosted internally (i.e MADiE-Root Repo).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
