### PR TITLE
slack/ProtocolFlag: Adding a build script that will run app as http/h…

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,17 @@ Measure Application
 npm install .
 
 ```
+
+# Running the application
+
+Running server with http
+
+```
+npm run start
+```
+
+Running Server with https
+
+```
+npm run starts
+```

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
     "dist/**/*"
   ],
   "scripts": {
-    "start": "webpack serve --port 8505",
+    "starts": "webpack serve --port 8505 --env=protocol=https",
+    "start": "webpack serve --port 8505 --env=protocol=http",
     "build": "concurrently npm:build:*",
     "build:webpack": "webpack --mode=production",
     "analyze": "webpack --mode=production --env analyze",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,20 +6,32 @@ const singleSpaDefaults = require("webpack-config-single-spa-react-ts");
 const path = require("path");
 const fs = require("fs");
 
-let https;
-console.log("Dir Name " + __dirname);
-try {
-  https = {
-    key: fs.readFileSync(path.resolve(__dirname, "localhost.key"), "utf-8"),
-    cert: fs.readFileSync(path.resolve(__dirname, "localhost.crt"), "utf-8"),
-  };
-} catch {
-  console.warn(
-    "Consider creating an SSL certificate at ./localhost.key and ./localhost.crt, so you can tell your operating system to trust the certificate"
-  );
-}
-
 module.exports = (webpackConfigEnv, argv) => {
+  const protocol = webpackConfigEnv.protocol
+    ? webpackConfigEnv.protocol
+    : "http";
+  console.log("Branch Name " + protocol);
+
+  let https;
+  console.log("Dir Name " + __dirname);
+  try {
+    if (protocol === "https") {
+      https = {
+        key: fs.readFileSync(path.resolve(__dirname, "localhost.key"), "utf-8"),
+        cert: fs.readFileSync(
+          path.resolve(__dirname, "localhost.crt"),
+          "utf-8"
+        ),
+      };
+    } else {
+      https = false;
+    }
+  } catch {
+    console.warn(
+      "Consider creating an SSL certificate at ./localhost.key and ./localhost.crt, so you can tell your operating system to trust the certificate"
+    );
+  }
+
   const defaultConfig = singleSpaDefaults({
     orgName: "madie",
     projectName: "madie-measure",


### PR DESCRIPTION
…ttps depending on the flag

## MADiE PR

Jira Ticket: Slack - Process Improvement
(Optional) Related Tickets:

### Summary
Adding a flag so that madie-measure can be started with HTTP or HTTPS.. https allows it to integrate with the remote development tools that SingleSpa provides

### All Submissions
* [X] This PR has the JIRA linked.
* [X] No extemporaneous files are included (i.e Complied files or testing results).
* [X] This PR is merging into the **correct branch**.
* [X] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [X] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).
* [ ] All CDN/Web dependancies are hosted internally (i.e MADiE-Root Repo).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
