### PR TITLE
Add Timeout Handler and tests, initialize to 25 minute session

### DIFF
--- a/src/components/measureLanding/MeasureLanding.test.tsx
+++ b/src/components/measureLanding/MeasureLanding.test.tsx
@@ -55,7 +55,11 @@ jest.mock("../../api/useMeasureServiceApi", () =>
 
 describe("MeasureLanding", () => {
   test("shows the children when the checkbox is checked", async () => {
-    render(<MeasureLanding />);
+    render(
+      <div id="main">
+        <MeasureLanding />
+      </div>
+    );
 
     expect(screen.getByTestId("browser-router")).toBeTruthy();
     const measure1 = await screen.findByText("TestMeasure1");

--- a/src/components/measureLanding/MeasureLanding.tsx
+++ b/src/components/measureLanding/MeasureLanding.tsx
@@ -3,6 +3,7 @@ import { Route, Switch, BrowserRouter, Redirect } from "react-router-dom";
 import { CreateNewMeasure } from "../createNewMeasure/CreateNewMeasure";
 import EditMeasure from "../editMeasure/EditMeasure";
 import NewMeasure from "../newMeasure/NewMeasure";
+import TimeoutHandler from "./TimeoutHandler";
 
 export function MeasureRoutes() {
   return (
@@ -15,12 +16,14 @@ export function MeasureRoutes() {
   );
 }
 
-export default function MeasureLanding() {
+const MeasureLanding = () => {
   return (
     <div data-testid="browser-router">
+      <TimeoutHandler timeLeft={1500000} />
       <BrowserRouter>
         <MeasureRoutes />
       </BrowserRouter>
     </div>
   );
-}
+};
+export default MeasureLanding;

--- a/src/components/measureLanding/TimeoutHandler.test.tsx
+++ b/src/components/measureLanding/TimeoutHandler.test.tsx
@@ -41,9 +41,18 @@ describe("Measure Groups Page", () => {
   test("Timeout handler renders after 10 seconds, disappears on outer click", async () => {
     setTimeout(() => {
       expect(screen.getByTestId("warn-timeout-title")).toBeTruthy();
-      const alertTitle = screen.queryByText("Session Expiration Warning");
       const outerDiv = screen.getAllByTestId("sentinelStart");
       outerDiv.click();
+      expect(alertTitle).toBeNull();
+    }, 10000);
+  });
+
+  test("Timeout handler renders after 10 seconds, disappears on mouse move", async () => {
+    setTimeout(() => {
+      expect(screen.getByTestId("warn-timeout-title")).toBeTruthy();
+      const alertTitle = screen.queryByText("Session Expiration Warning");
+      const mouseMove = new Event("mousemove");
+      document.dispatchEvent(mouseMove);
       expect(alertTitle).toBeNull();
     }, 10000);
   });

--- a/src/components/measureLanding/TimeoutHandler.test.tsx
+++ b/src/components/measureLanding/TimeoutHandler.test.tsx
@@ -1,0 +1,50 @@
+import * as React from "react";
+import { render, screen } from "@testing-library/react";
+import TimeoutHandler from "./TimeoutHandler";
+
+describe("Measure Groups Page", () => {
+  const renderTimeoutHandler = () => {
+    return render(
+      <div id="main">
+        <TimeoutHandler timeLeft={10000} />
+      </div>
+    );
+  };
+  beforeEach(() => {
+    renderTimeoutHandler();
+  });
+
+  test("Timeout Handler does not render initially", async () => {
+    const alertTitle = screen.queryByText("Session Expiration Warning");
+    expect(alertTitle).toBeNull();
+  });
+
+  test("Timeout handler renders after 10 seconds, disappears on keypress escape", async () => {
+    setTimeout(() => {
+      expect(screen.getByTestId("warn-timeout-title")).toBeTruthy();
+      const event = new KeyboardEvent("keydown", { keyCode: 27 });
+      document.dispatchEvent(event);
+      const alertTitle = screen.queryByText("Session Expiration Warning");
+      expect(alertTitle).toBeNull();
+    }, 10000);
+  });
+
+  test("Timeout handler renders after 10 seconds, disappears on alert click", async () => {
+    setTimeout(() => {
+      expect(screen.getByTestId("warn-timeout-title")).toBeTruthy();
+      const alertTitle = screen.queryByText("Session Expiration Warning");
+      alertTitle.click();
+      expect(alertTitle).toBeNull();
+    }, 10000);
+  });
+
+  test("Timeout handler renders after 10 seconds, disappears on outer click", async () => {
+    setTimeout(() => {
+      expect(screen.getByTestId("warn-timeout-title")).toBeTruthy();
+      const alertTitle = screen.queryByText("Session Expiration Warning");
+      const outerDiv = screen.getAllByTestId("sentinelStart");
+      outerDiv.click();
+      expect(alertTitle).toBeNull();
+    }, 10000);
+  });
+});

--- a/src/components/measureLanding/TimeoutHandler.tsx
+++ b/src/components/measureLanding/TimeoutHandler.tsx
@@ -4,7 +4,6 @@ import {
   DialogTitle,
   DialogContent,
   DialogContentText,
-  DialogActions,
 } from "@mui/material";
 
 export interface timeoutPropTypes {
@@ -56,7 +55,6 @@ const TimeoutHandler = ({ timeLeft = 10000 }) => {
             inactivity.
           </DialogContentText>
         </DialogContent>
-        <DialogActions></DialogActions>
       </div>
     </Dialog>
   );

--- a/src/components/measureLanding/TimeoutHandler.tsx
+++ b/src/components/measureLanding/TimeoutHandler.tsx
@@ -1,0 +1,65 @@
+import React, { useState, useCallback, useRef, useLayoutEffect } from "react";
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogContentText,
+  DialogActions,
+} from "@mui/material";
+
+export interface timeoutPropTypes {
+  timeLeft: number;
+}
+
+const TimeoutHandler = ({ timeLeft = 10000 }) => {
+  const timeoutRef = useRef<any>(null);
+  const [timingOut, setTimingOut] = useState<boolean>(false);
+
+  const timeoutCallBack = () => {
+    setTimingOut(true);
+  };
+
+  const resetTimeout = useCallback(() => {
+    clearTimeout(timeoutRef.current);
+    setTimingOut(false);
+    timeoutRef.current = setTimeout(timeoutCallBack, timeLeft);
+  }, [timeLeft]);
+
+  // initialize
+  useLayoutEffect(() => {
+    const rootNode = document.getElementById("main");
+    timeoutRef.current = setTimeout(timeoutCallBack, timeLeft);
+    rootNode.addEventListener("keypress", timeoutCallBack);
+    rootNode.addEventListener("click", timeoutCallBack);
+    return () => {
+      rootNode.removeEventListener("keypress", timeoutCallBack);
+      rootNode.removeEventListener("click", timeoutCallBack);
+      clearTimeout(timeoutRef.current);
+    };
+  }, [resetTimeout, timeLeft, timeoutRef]);
+  return (
+    <Dialog
+      open={timingOut}
+      onKeyDown={resetTimeout}
+      onClose={resetTimeout}
+      aria-labelledby="warn-timeout-title"
+      aria-describedby="warn-timeout-description"
+    >
+      {/* we want clicks inside to also trigger reset */}
+      <div role="button" tabIndex={0} onClick={resetTimeout}>
+        <DialogTitle id="warn-timeout-title">
+          Session Expiration Warning
+        </DialogTitle>
+        <DialogContent>
+          <DialogContentText id="warn-timeout-description">
+            Your session is about to expire due to an extended period of
+            inactivity.
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions></DialogActions>
+      </div>
+    </Dialog>
+  );
+};
+
+export default TimeoutHandler;

--- a/src/components/measureLanding/TimeoutHandler.tsx
+++ b/src/components/measureLanding/TimeoutHandler.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useCallback, useRef, useLayoutEffect } from "react";
+import { throttle } from "lodash";
 import {
   Dialog,
   DialogTitle,
@@ -18,28 +19,39 @@ const TimeoutHandler = ({ timeLeft = 10000 }) => {
     setTimingOut(true);
   };
 
-  const resetTimeout = useCallback(() => {
-    clearTimeout(timeoutRef.current);
-    setTimingOut(false);
-    timeoutRef.current = setTimeout(timeoutCallBack, timeLeft);
-  }, [timeLeft]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const resetTimeout = useCallback(
+    throttle(
+      () => {
+        setTimingOut(false);
+        clearTimeout(timeoutRef.current);
+        timeoutRef.current = setTimeout(timeoutCallBack, timeLeft);
+      },
+      500,
+      { leading: true }
+    ),
+    [timeLeft]
+  );
 
   // initialize
   useLayoutEffect(() => {
     const rootNode = document.getElementById("main");
     timeoutRef.current = setTimeout(timeoutCallBack, timeLeft);
-    rootNode.addEventListener("keypress", timeoutCallBack);
-    rootNode.addEventListener("click", timeoutCallBack);
+    rootNode.addEventListener("keypress", resetTimeout);
+    rootNode.addEventListener("click", resetTimeout);
+    rootNode.addEventListener("mousemove", resetTimeout);
     return () => {
-      rootNode.removeEventListener("keypress", timeoutCallBack);
-      rootNode.removeEventListener("click", timeoutCallBack);
+      rootNode.removeEventListener("keypress", resetTimeout);
+      rootNode.removeEventListener("click", resetTimeout);
+      rootNode.removeEventListener("mouseMove", resetTimeout);
       clearTimeout(timeoutRef.current);
     };
-  }, [resetTimeout, timeLeft, timeoutRef]);
+  }, [resetTimeout, timeoutRef, timeLeft]);
   return (
     <Dialog
       open={timingOut}
       onKeyDown={resetTimeout}
+      onMouseMove={resetTimeout}
       onClose={resetTimeout}
       aria-labelledby="warn-timeout-title"
       aria-describedby="warn-timeout-description"


### PR DESCRIPTION
## MADiE PR

Jira Ticket: [MAT-3810](https://jira.cms.gov/browse/MAT-3819)
(Optional) Related Tickets:

### Summary
This PR adds a session timeout warning that appears after 25 minutes.
Timeout handler is reset on synthetic keypress and click events

### All Submissions
* [x] This PR has the JIRA linked.
* [x] Required tests are included.
* [x] No extemporaneous files are included (i.e Complied files or testing results).
* [x] This PR is merging into the **correct branch**.
* [x] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [x] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).
* [ ] All CDN/Web dependencies are hosted internally (i.e MADiE-Root Repo).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
