### PR TITLE
Feature 3917/population reset

### DIFF
--- a/src/components/measureGroups/MeasureGroupPopulationSelect.tsx
+++ b/src/components/measureGroups/MeasureGroupPopulationSelect.tsx
@@ -84,7 +84,7 @@ const MeasureGroupPopulationSelect = ({
           <Select
             native
             displayEmpty
-            value={value.replace(/"/g, "")}
+            value={value?.replace(/"/g, "")}
             id={htmlId}
             inputProps={{
               "data-testid": `select-measure-group-population`,
@@ -105,10 +105,11 @@ const MeasureGroupPopulationSelect = ({
             ))}
             <option
               value={""}
-              disabled
+              disabled={required}
               data-testid={`select-option-measure-group-population`}
             >
-              Select {defaultOptionTitle}
+              Select {defaultOptionTitle}{" "}
+              {required ? "" : "( Leave selected for no population )"}
             </option>
           </Select>
         </Col>

--- a/src/components/measureGroups/MeasureGroups.test.tsx
+++ b/src/components/measureGroups/MeasureGroups.test.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { render, screen, act, within } from "@testing-library/react";
+import { render, screen, act, within, fireEvent } from "@testing-library/react";
 import { isEqual } from "lodash";
 import MeasureGroups, {
   DefaultPopulationSelectorDefinitions,
@@ -142,6 +142,27 @@ describe("Measure Groups Page", () => {
       expect(options.length).toBe(11);
       expect(def[0].textContent).toBe("SDE Ethnicity");
     }
+  });
+
+  test("On change of group scoring the field definitions are cleared", () => {
+    group.id = "";
+    measure.groups = [group];
+    renderMeasureGroupComponent();
+    userEvent.selectOptions(
+      screen.getByTestId("scoring-unit-select"),
+      screen.getByRole("option", { name: "Cohort" })
+    );
+    expect(screen.getByRole("option", { name: "Cohort" }).selected).toBe(true);
+    const option = screen.getByTestId("scoring-unit-select");
+
+    const populationOption = screen.getAllByTestId(
+      "select-measure-group-population"
+    )[0];
+    expect(populationOption.value).toBe(group.population.initialPopulation);
+
+    fireEvent.change(option, { target: { value: "Ratio" } });
+    expect(option.value).toBe("Ratio");
+    expect(populationOption.value).toBe("");
   });
 
   test("Should create population Group with one initial population successfully", async () => {

--- a/src/components/measureGroups/MeasureGroups.tsx
+++ b/src/components/measureGroups/MeasureGroups.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, Fragment } from "react";
+import React, { useEffect, useState, Fragment, useRef } from "react";
 import tw, { styled } from "twin.macro";
 import useCurrentMeasure from "../editMeasure/useCurrentMeasure";
 import { MeasureScoring } from "../../models/MeasureScoring";
@@ -107,7 +107,7 @@ const MeasureGroups = () => {
   const [expressionDefinitions, setExpressionDefinitions] = useState<
     Array<ExpressionDefinition>
   >([]);
-  const { measure } = useCurrentMeasure();
+  const { measure, setMeasure } = useCurrentMeasure();
   const measureServiceApi = useMeasureServiceApi();
   const [genericErrorMessage, setGenericErrorMessage] = useState<string>();
   const [successMessage, setSuccessMessage] = useState<string>();
@@ -115,6 +115,7 @@ const MeasureGroups = () => {
   // TODO: group will be coming from props when we separate this into separate component
   const group = measure.groups && measure.groups[0];
   const defaultScoring = group?.scoring || measure?.measureScoring || "Cohort";
+  const canReset = useRef(false);
   const formik = useFormik({
     initialValues: {
       id: group?.id || null,
@@ -144,6 +145,25 @@ const MeasureGroups = () => {
       setExpressionDefinitions(definitions);
     }
   }, [measure]);
+
+  useEffect(() => {
+    if (formik.values.scoring && formik.values.scoring !== "") {
+      if (!canReset.current) {
+        canReset.current = true;
+      } else {
+        formik.setFieldValue("population", {
+          initialPopulation: "",
+          denominator: "",
+          denominatorExclusion: "",
+          denominatorException: "",
+          numerator: "",
+          numeratorExclusion: "",
+          measurePopulation: "",
+          measurePopulationExclusion: "",
+        });
+      }
+    }
+  }, [formik.values.scoring, formik.setFieldValue]);
 
   // @TODO: Pull directly from MeasurePopulation instead of local export
   const PopulationSelectorDefinitions = DefaultPopulationSelectorDefinitions;
@@ -182,22 +202,30 @@ const MeasureGroups = () => {
     if (group.id) {
       measureServiceApi
         .updateGroup(group, measure.id)
-        .then((g: Group) =>
+        .then((g: Group) => {
           setSuccessMessage(
             "Population details for this group updated successfully."
-          )
-        )
+          );
+          setMeasure({
+            ...measure,
+            groups: [g],
+          });
+        })
         .catch((error) => {
           setGenericErrorMessage(error.message);
         });
     } else {
       measureServiceApi
         .createGroup(group, measure.id)
-        .then((g: Group) =>
+        .then((g: Group) => {
           setSuccessMessage(
             "Population details for this group saved successfully."
-          )
-        )
+          );
+          setMeasure({
+            ...measure,
+            groups: [g],
+          });
+        })
         .catch((error) => {
           setGenericErrorMessage(error.message);
         });


### PR DESCRIPTION
## MADiE PR

Jira Ticket: [MAT-3917](https://jira.cms.gov/browse/MAT-3917)
(Optional) Related Tickets:

### Summary
Reseting the fields when the population scoring is changed

### All Submissions
* [x] This PR has the JIRA linked.
* [x] Required tests are included.
* [ ] No extemporaneous files are included (i.e Complied files or testing results).
* [ ] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).
* [ ] All CDN/Web dependencies are hosted internally (i.e MADiE-Root Repo).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
