### PR TITLE
Feature 3917/population reset

### DIFF
--- a/src/components/measureGroups/MeasureGroups.test.tsx
+++ b/src/components/measureGroups/MeasureGroups.test.tsx
@@ -265,13 +265,9 @@ describe("Measure Groups Page", () => {
 
     // submit the form
     userEvent.click(screen.getByTestId("group-form-submit-btn"));
-    const alert = await screen.findByTestId("warning-alerts");
-    expect(alert).toBeInTheDocument();
+    const alert = await screen.findByTestId("success-alerts");
 
-    userEvent.click(screen.getByTestId("group-form-update-btn"));
-    const successAlert = await screen.findByTestId("success-alerts");
-
-    expect(successAlert).toHaveTextContent(
+    expect(alert).toHaveTextContent(
       "Population details for this group updated successfully."
     );
     expect(mockedAxios.put).toHaveBeenCalledWith(
@@ -337,13 +333,9 @@ describe("Measure Groups Page", () => {
 
     // submit the form
     userEvent.click(screen.getByTestId("group-form-submit-btn"));
-    const alert = await screen.findByTestId("warning-alerts");
+    const alert = await screen.findByTestId("error-alerts");
     expect(alert).toBeInTheDocument();
-
-    userEvent.click(screen.getByTestId("group-form-update-btn"));
-    const errorAlert = await screen.findByTestId("error-alerts");
-    expect(errorAlert).toBeInTheDocument();
-    expect(errorAlert).toHaveTextContent("Failed to update the group.");
+    expect(alert).toHaveTextContent("Failed to update the group.");
   });
 
   test("Should report an error if the update population Group fails due to group validation error", async () => {
@@ -380,13 +372,9 @@ describe("Measure Groups Page", () => {
 
     // submit the form
     userEvent.click(screen.getByTestId("group-form-submit-btn"));
-    const alert = await screen.findByTestId("warning-alerts");
+    const alert = await screen.findByTestId("error-alerts");
     expect(alert).toBeInTheDocument();
-
-    userEvent.click(screen.getByTestId("group-form-update-btn"));
-    const errorAlert = await screen.findByTestId("error-alerts");
-    expect(errorAlert).toBeInTheDocument();
-    expect(errorAlert).toHaveTextContent(
+    expect(alert).toHaveTextContent(
       "Failed to update the group. Missing required populations for selected scoring type."
     );
   });

--- a/src/components/measureGroups/MeasureGroups.test.tsx
+++ b/src/components/measureGroups/MeasureGroups.test.tsx
@@ -200,58 +200,61 @@ describe("Measure Groups Page", () => {
     );
   });
 
-  test("Should be able to update initial population of a population group", async () => {
-    group.id = "7p03-5r29-7O0I";
-    measure.groups = [group];
-    renderMeasureGroupComponent();
+  // test("Should be able to update initial population of a population group", async () => {
+  //   group.id = "7p03-5r29-7O0I";
+  //   measure.groups = [group];
+  //   renderMeasureGroupComponent();
 
-    // initial population before update
-    expect(
-      screen.getByRole("option", {
-        name: "Initial Population",
-      }).selected
-    ).toBe(true);
+  //   // initial population before update
+  //   expect(
+  //     screen.getByRole("option", {
+  //       name: "Initial Population",
+  //     }).selected
+  //   ).toBe(true);
 
-    const definitionToUpdate =
-      "VTE Prophylaxis by Medication Administered or Device Applied";
-    // update initial population from dropdown
-    userEvent.selectOptions(
-      screen.getByTestId("select-measure-group-population"),
-      screen.getByText(definitionToUpdate)
-    );
+  //   const definitionToUpdate =
+  //     "VTE Prophylaxis by Medication Administered or Device Applied";
+  //   // update initial population from dropdown
+  //   userEvent.selectOptions(
+  //     screen.getByTestId("select-measure-group-population"),
+  //     screen.getByText(definitionToUpdate)
+  //   );
 
-    expect(
-      screen.getByRole("option", {
-        name: definitionToUpdate,
-      }).selected
-    ).toBe(true);
+  //   expect(
+  //     screen.getByRole("option", {
+  //       name: definitionToUpdate,
+  //     }).selected
+  //   ).toBe(true);
 
-    group.population.initialPopulation = definitionToUpdate;
+  //   group.population.initialPopulation = definitionToUpdate;
 
-    mockedAxios.put.mockResolvedValue({ data: { group } });
+  //   mockedAxios.put.mockResolvedValue({ data: { group } });
 
-    const expectedGroup = {
-      id: "7p03-5r29-7O0I",
-      population: {
-        initialPopulation:
-          "VTE Prophylaxis by Medication Administered or Device Applied",
-      },
-      scoring: "Cohort",
-    };
+  //   const expectedGroup = {
+  //     id: "7p03-5r29-7O0I",
+  //     population: {
+  //       initialPopulation:
+  //         "VTE Prophylaxis by Medication Administered or Device Applied",
+  //     },
+  //     scoring: "Cohort",
+  //   };
 
-    // submit the form
-    userEvent.click(screen.getByTestId("group-form-submit-btn"));
-    const alert = await screen.findByTestId("success-alerts");
+  //   // submit the form
+  //   userEvent.click(screen.getByTestId("group-form-submit-btn"));
+  //   const alert = await screen.findByTestId("success-alerts");
 
-    expect(alert).toHaveTextContent(
-      "Population details for this group updated successfully."
-    );
-    expect(mockedAxios.put).toHaveBeenCalledWith(
-      "example-service-url/measures/test-measure/groups/",
-      expectedGroup,
-      expect.anything()
-    );
-  });
+  //   //const alert = await screen.findByTestId("warning-alerts");
+  //   //expect(alert).toBeInTheDocument();
+
+  //   expect(alert).toHaveTextContent(
+  //     "Population details for this group updated successfully."
+  //   );
+  //   expect(mockedAxios.put).toHaveBeenCalledWith(
+  //     "example-service-url/measures/test-measure/groups/",
+  //     expectedGroup,
+  //     expect.anything()
+  //   );
+  // });
 
   test("Should report an error if create population Group fails", async () => {
     renderMeasureGroupComponent();
@@ -277,32 +280,32 @@ describe("Measure Groups Page", () => {
     expect(alert).toHaveTextContent("Failed to create the group.");
   });
 
-  test("Should report an error if the update population Group fails", async () => {
-    group.id = "7p03-5r29-7O0I";
-    measure.groups = [group];
-    renderMeasureGroupComponent();
-    // update initial population from dropdown
-    const definitionToUpdate =
-      "VTE Prophylaxis by Medication Administered or Device Applied";
-    userEvent.selectOptions(
-      screen.getByTestId("select-measure-group-population"),
-      screen.getByText(definitionToUpdate)
-    );
+  // test("Should report an error if the update population Group fails", async () => {
+  //   group.id = "7p03-5r29-7O0I";
+  //   measure.groups = [group];
+  //   renderMeasureGroupComponent();
+  //   // update initial population from dropdown
+  //   const definitionToUpdate =
+  //     "VTE Prophylaxis by Medication Administered or Device Applied";
+  //   userEvent.selectOptions(
+  //     screen.getByTestId("select-measure-group-population"),
+  //     screen.getByText(definitionToUpdate)
+  //   );
 
-    expect(
-      screen.getByRole("option", { name: definitionToUpdate }).selected
-    ).toBe(true);
+  //   expect(
+  //     screen.getByRole("option", { name: definitionToUpdate }).selected
+  //   ).toBe(true);
 
-    mockedAxios.put.mockRejectedValue({
-      data: {
-        error: "500error",
-      },
-    });
+  //   mockedAxios.put.mockRejectedValue({
+  //     data: {
+  //       error: "500error",
+  //     },
+  //   });
 
-    // submit the form
-    userEvent.click(screen.getByTestId("group-form-submit-btn"));
-    const alert = await screen.findByTestId("error-alerts");
-    expect(alert).toBeInTheDocument();
-    expect(alert).toHaveTextContent("Failed to update the group.");
-  });
+  //   // submit the form
+  //   userEvent.click(screen.getByTestId("group-form-submit-btn"));
+  //   const alert = await screen.findByTestId("error-alerts");
+  //   expect(alert).toBeInTheDocument();
+  //   expect(alert).toHaveTextContent("Failed to update the group.");
+  // });
 });

--- a/src/components/measureGroups/MeasureGroups.test.tsx
+++ b/src/components/measureGroups/MeasureGroups.test.tsx
@@ -220,62 +220,66 @@ describe("Measure Groups Page", () => {
     );
   });
 
-  // test("Should be able to update initial population of a population group", async () => {
-  //   group.id = "7p03-5r29-7O0I";
-  //   measure.groups = [group];
-  //   renderMeasureGroupComponent();
+  test("Should be able to update initial population of a population group", async () => {
+    group.id = "7p03-5r29-7O0I";
+    measure.groups = [group];
+    renderMeasureGroupComponent();
 
-  //   // initial population before update
-  //   expect(
-  //     (
-  //       screen.getByRole("option", {
-  //         name: "Initial Population",
-  //       }) as HTMLOptionElement
-  //     ).selected
-  //   ).toBe(true);
+    // initial population before update
+    expect(
+      (
+        screen.getByRole("option", {
+          name: "Initial Population",
+        }) as HTMLOptionElement
+      ).selected
+    ).toBe(true);
 
-  //   const definitionToUpdate =
-  //     "VTE Prophylaxis by Medication Administered or Device Applied";
-  //   // update initial population from dropdown
-  //   userEvent.selectOptions(
-  //     screen.getByTestId("select-measure-group-population"),
-  //     screen.getByText(definitionToUpdate)
-  //   );
+    const definitionToUpdate =
+      "VTE Prophylaxis by Medication Administered or Device Applied";
+    // update initial population from dropdown
+    userEvent.selectOptions(
+      screen.getByTestId("select-measure-group-population"),
+      screen.getByText(definitionToUpdate)
+    );
 
-  //   expect(
-  //     (
-  //       screen.getByRole("option", {
-  //         name: definitionToUpdate,
-  //       }) as HTMLOptionElement
-  //     ).selected
-  //   ).toBe(true);
+    expect(
+      (
+        screen.getByRole("option", {
+          name: definitionToUpdate,
+        }) as HTMLOptionElement
+      ).selected
+    ).toBe(true);
 
-  //   group.population.initialPopulation = definitionToUpdate;
+    group.population.initialPopulation = definitionToUpdate;
 
-  //   mockedAxios.put.mockResolvedValue({ data: { group } });
+    mockedAxios.put.mockResolvedValue({ data: { group } });
 
-  //   const expectedGroup = {
-  //     id: "7p03-5r29-7O0I",
-  //     population: {
-  //       initialPopulation:
-  //         "VTE Prophylaxis by Medication Administered or Device Applied",
-  //     },
-  //     scoring: "Cohort",
-  //   };
+    const expectedGroup = {
+      id: "7p03-5r29-7O0I",
+      population: {
+        initialPopulation:
+          "VTE Prophylaxis by Medication Administered or Device Applied",
+      },
+      scoring: "Cohort",
+    };
 
-  //   // submit the form
-  //   userEvent.click(screen.getByTestId("group-form-submit-btn"));
-  //   const alert = await screen.findByTestId("success-alerts");
+    // submit the form
+    userEvent.click(screen.getByTestId("group-form-submit-btn"));
+    const alert = await screen.findByTestId("warning-alerts");
+    expect(alert).toBeInTheDocument();
 
-  //   expect(alert).toHaveTextContent(
-  //     "Population details for this group updated successfully."
-  //   );
-  //   expect(mockedAxios.put).toHaveBeenCalledWith(
-  //     "example-service-url/measures/test-measure/groups/",
-  //     expectedGroup,
-  //     expect.anything()
-  //   );
-  // });
+    userEvent.click(screen.getByTestId("group-form-update-btn"));
+    const successAlert = await screen.findByTestId("success-alerts");
+
+    expect(successAlert).toHaveTextContent(
+      "Population details for this group updated successfully."
+    );
+    expect(mockedAxios.put).toHaveBeenCalledWith(
+      "example-service-url/measures/test-measure/groups/",
+      expectedGroup,
+      expect.anything()
+    );
+  });
 
   test("Should report an error if create population Group fails", async () => {
     renderMeasureGroupComponent();
@@ -305,79 +309,87 @@ describe("Measure Groups Page", () => {
     expect(alert).toHaveTextContent("Failed to create the group.");
   });
 
-  // test("Should report an error if the update population Group fails", async () => {
-  //   group.id = "7p03-5r29-7O0I";
-  //   measure.groups = [group];
-  //   renderMeasureGroupComponent();
-  //   // update initial population from dropdown
-  //   const definitionToUpdate =
-  //     "VTE Prophylaxis by Medication Administered or Device Applied";
-  //   userEvent.selectOptions(
-  //     screen.getByTestId("select-measure-group-population"),
-  //     screen.getByText(definitionToUpdate)
-  //   );
+  test("Should report an error if the update population Group fails", async () => {
+    group.id = "7p03-5r29-7O0I";
+    measure.groups = [group];
+    renderMeasureGroupComponent();
+    // update initial population from dropdown
+    const definitionToUpdate =
+      "VTE Prophylaxis by Medication Administered or Device Applied";
+    userEvent.selectOptions(
+      screen.getByTestId("select-measure-group-population"),
+      screen.getByText(definitionToUpdate)
+    );
 
-  //   expect(
-  //     (
-  //       screen.getByRole("option", {
-  //         name: definitionToUpdate,
-  //       }) as HTMLOptionElement
-  //     ).selected
-  //   ).toBe(true);
+    expect(
+      (
+        screen.getByRole("option", {
+          name: definitionToUpdate,
+        }) as HTMLOptionElement
+      ).selected
+    ).toBe(true);
 
-  //   mockedAxios.put.mockRejectedValue({
-  //     data: {
-  //       error: "500error",
-  //     },
-  //   });
+    mockedAxios.put.mockRejectedValue({
+      data: {
+        error: "500error",
+      },
+    });
 
-  //   // submit the form
-  //   userEvent.click(screen.getByTestId("group-form-submit-btn"));
-  //   const alert = await screen.findByTestId("error-alerts");
-  //   expect(alert).toBeInTheDocument();
-  //   expect(alert).toHaveTextContent("Failed to update the group.");
-  // });
+    // submit the form
+    userEvent.click(screen.getByTestId("group-form-submit-btn"));
+    const alert = await screen.findByTestId("warning-alerts");
+    expect(alert).toBeInTheDocument();
 
-  // test("Should report an error if the update population Group fails due to group validation error", async () => {
-  //   group.id = "7p03-5r29-7O0I";
-  //   measure.groups = [group];
-  //   renderMeasureGroupComponent();
-  //   // update initial population from dropdown
-  //   const definitionToUpdate =
-  //     "VTE Prophylaxis by Medication Administered or Device Applied";
-  //   userEvent.selectOptions(
-  //     screen.getByTestId("select-measure-group-population"),
-  //     screen.getByText(definitionToUpdate)
-  //   );
+    userEvent.click(screen.getByTestId("group-form-update-btn"));
+    const errorAlert = await screen.findByTestId("error-alerts");
+    expect(errorAlert).toBeInTheDocument();
+    expect(errorAlert).toHaveTextContent("Failed to update the group.");
+  });
 
-  //   expect(
-  //     (
-  //       screen.getByRole("option", {
-  //         name: definitionToUpdate,
-  //       }) as HTMLOptionElement
-  //     ).selected
-  //   ).toBe(true);
+  test("Should report an error if the update population Group fails due to group validation error", async () => {
+    group.id = "7p03-5r29-7O0I";
+    measure.groups = [group];
+    renderMeasureGroupComponent();
+    // update initial population from dropdown
+    const definitionToUpdate =
+      "VTE Prophylaxis by Medication Administered or Device Applied";
+    userEvent.selectOptions(
+      screen.getByTestId("select-measure-group-population"),
+      screen.getByText(definitionToUpdate)
+    );
 
-  //   mockedAxios.put.mockRejectedValue({
-  //     response: {
-  //       status: 400,
-  //       data: {
-  //         error: "400error",
-  //         validationErrors: {
-  //           group: "Populations do not match Scoring",
-  //         },
-  //       },
-  //     },
-  //   });
+    expect(
+      (
+        screen.getByRole("option", {
+          name: definitionToUpdate,
+        }) as HTMLOptionElement
+      ).selected
+    ).toBe(true);
 
-  //   // submit the form
-  //   userEvent.click(screen.getByTestId("group-form-submit-btn"));
-  //   const alert = await screen.findByTestId("error-alerts");
-  //   expect(alert).toBeInTheDocument();
-  //   expect(alert).toHaveTextContent(
-  //     "Failed to update the group. Missing required populations for selected scoring type."
-  //   );
-  // });
+    mockedAxios.put.mockRejectedValue({
+      response: {
+        status: 400,
+        data: {
+          error: "400error",
+          validationErrors: {
+            group: "Populations do not match Scoring",
+          },
+        },
+      },
+    });
+
+    // submit the form
+    userEvent.click(screen.getByTestId("group-form-submit-btn"));
+    const alert = await screen.findByTestId("warning-alerts");
+    expect(alert).toBeInTheDocument();
+
+    userEvent.click(screen.getByTestId("group-form-update-btn"));
+    const errorAlert = await screen.findByTestId("error-alerts");
+    expect(errorAlert).toBeInTheDocument();
+    expect(errorAlert).toHaveTextContent(
+      "Failed to update the group. Missing required populations for selected scoring type."
+    );
+  });
 
   test("Form displays message next to save button about required populations", async () => {
     renderMeasureGroupComponent();

--- a/src/components/measureGroups/MeasureGroups.tsx
+++ b/src/components/measureGroups/MeasureGroups.tsx
@@ -143,7 +143,10 @@ const MeasureGroups = () => {
     onSubmit: (group: Group) => {
       setSuccessMessage(undefined);
       window.scrollTo(0, 0);
-      if (measure?.groups) {
+      if (
+        measure?.groups &&
+        formik.values.scoring !== measure.groups[0].scoring
+      ) {
         setWarningMessage(true);
         if (updateConfirm) {
           setWarningMessage(false);

--- a/src/components/measureGroups/MeasureGroups.tsx
+++ b/src/components/measureGroups/MeasureGroups.tsx
@@ -111,6 +111,8 @@ const MeasureGroups = () => {
   const measureServiceApi = useMeasureServiceApi();
   const [genericErrorMessage, setGenericErrorMessage] = useState<string>();
   const [successMessage, setSuccessMessage] = useState<string>();
+  const [warningMessage, setWarningMessage] = useState<boolean>(false);
+  const [updateConfirm, setUpdateConfirm] = useState<boolean>(false);
   // TODO: hardcoded index 0 as only one group is there.
   // TODO: group will be coming from props when we separate this into separate component
   const group = measure.groups && measure.groups[0];
@@ -134,7 +136,18 @@ const MeasureGroups = () => {
     } as Group,
     validationSchema: MeasureGroupSchemaValidator,
     onSubmit: (group: Group) => {
-      submitForm(group);
+      setSuccessMessage(undefined);
+      window.scrollTo(0, 0);
+      if (measure?.groups) {
+        setWarningMessage(true);
+        if (updateConfirm) {
+          setWarningMessage(false);
+          submitForm(group);
+          setUpdateConfirm(false);
+        }
+      } else {
+        submitForm(group);
+      }
     },
   });
 
@@ -199,18 +212,23 @@ const MeasureGroups = () => {
         (value) => _.isNil(value) || value.trim().length === 0
       );
     }
-    if (group.id) {
+
+    if (measure?.groups) {
+      group.id = measure.groups[0].id;
       measureServiceApi
         .updateGroup(group, measure.id)
         .then((g: Group) => {
-          setSuccessMessage(
-            "Population details for this group updated successfully."
-          );
           setMeasure({
             ...measure,
             groups: [g],
           });
         })
+        .then(() => {
+          setSuccessMessage(
+            "Population details for this group updated successfully."
+          );
+        })
+
         .catch((error) => {
           setGenericErrorMessage(error.message);
         });
@@ -218,14 +236,17 @@ const MeasureGroups = () => {
       measureServiceApi
         .createGroup(group, measure.id)
         .then((g: Group) => {
-          setSuccessMessage(
-            "Population details for this group saved successfully."
-          );
           setMeasure({
             ...measure,
             groups: [g],
           });
         })
+        .then(() => {
+          setSuccessMessage(
+            "Population details for this group saved successfully."
+          );
+        })
+
         .catch((error) => {
           setGenericErrorMessage(error.message);
         });
@@ -240,6 +261,23 @@ const MeasureGroups = () => {
     },
   ];
   const allOptions = Object.values(MeasureScoring);
+
+  const warningTemplate = (
+    <>
+      <ButtonSpacer>
+        <Button
+          style={{ background: "#424B5A" }}
+          type="submit"
+          buttonTitle="Update"
+          data-testid="group-form-update-btn"
+          onClick={() => setUpdateConfirm(true)}
+        />
+      </ButtonSpacer>
+      <ButtonSpacer>
+        <Button type="button" buttonTitle="Cancel" variant="white" />
+      </ButtonSpacer>
+    </>
+  );
 
   return (
     <form onSubmit={formik.handleSubmit}>
@@ -267,6 +305,17 @@ const MeasureGroups = () => {
               onClose={() => setSuccessMessage(undefined)}
             >
               {successMessage}
+            </Alert>
+          )}
+          {warningMessage && (
+            <Alert
+              data-testid="warning-alerts"
+              role="alert"
+              severity="warning"
+              onClose={() => setWarningMessage(false)}
+            >
+              This change will reset the population scoring value in test cases.
+              Are you sure you wanted to continue with this? {warningTemplate}
             </Alert>
           )}
           {/* Form control later should be moved to own component and dynamically rendered by switch based on measure. */}


### PR DESCRIPTION
## MADiE PR

Jira Ticket: [MAT-4057](https://jira.cms.gov/browse/MAT-4057)
(Optional) Related Tickets:

### Summary
Displaying a warning while modifying the scoring and fixed the bug relating to store multiple array of population definitions

### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included.
* [ ] No extemporaneous files are included (i.e Complied files or testing results).
* [ ] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).
* [ ] All CDN/Web dependencies are hosted internally (i.e MADiE-Root Repo).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
