### PR TITLE
Mat-3967 Soft delete measure, requisite of 4126.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@emotion/styled": "^11.6.0",
         "@heroicons/react": "^1.0.5",
         "@madie/cql-antlr-parser": "^1.0.0",
-        "@madie/madie-design-system": "^1.0.8",
+        "@madie/madie-design-system": "^1.0.9",
         "@mui/icons-material": "^5.5.1",
         "@mui/material": "^5.2.5",
         "@mui/styles": "^5.5.1",
@@ -3132,9 +3132,9 @@
       }
     },
     "node_modules/@madie/madie-design-system": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@madie/madie-design-system/-/madie-design-system-1.0.8.tgz",
-      "integrity": "sha512-puUYo4AJ1VyDDDpirD+QMGsK4udqTgYVYr34A8yX2Fzhb2bAfB4Iw6y0csEIJaXvVaYs1+x4N1hwgbod452XxQ==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@madie/madie-design-system/-/madie-design-system-1.0.9.tgz",
+      "integrity": "sha512-1iIvZtN3ZXEefa6WWKBGb4GNBNEhEab15u8lS0P79+PagjjkURs8i6Cf4pgFlReYChvS5IQp4C4uI4+cSAD4Sw==",
       "dependencies": {
         "@cmsgov/design-system": "^2.13.0",
         "@emotion/react": "^11.8.2",
@@ -23562,9 +23562,9 @@
       }
     },
     "@madie/madie-design-system": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@madie/madie-design-system/-/madie-design-system-1.0.8.tgz",
-      "integrity": "sha512-puUYo4AJ1VyDDDpirD+QMGsK4udqTgYVYr34A8yX2Fzhb2bAfB4Iw6y0csEIJaXvVaYs1+x4N1hwgbod452XxQ==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@madie/madie-design-system/-/madie-design-system-1.0.9.tgz",
+      "integrity": "sha512-1iIvZtN3ZXEefa6WWKBGb4GNBNEhEab15u8lS0P79+PagjjkURs8i6Cf4pgFlReYChvS5IQp4C4uI4+cSAD4Sw==",
       "requires": {
         "@cmsgov/design-system": "^2.13.0",
         "@emotion/react": "^11.8.2",
@@ -36792,7 +36792,7 @@
             "async-each": "^1.0.1",
             "braces": "^2.3.2",
             "fsevents": "^1.2.7",
-            "glob-parent": "^5.1.2",
+            "glob-parent": "^3.1.0",
             "inherits": "^2.0.3",
             "is-binary-path": "^1.0.0",
             "is-glob": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "@emotion/styled": "^11.6.0",
     "@heroicons/react": "^1.0.5",
     "@madie/cql-antlr-parser": "^1.0.0",
-    "@madie/madie-design-system": "^1.0.8",
+    "@madie/madie-design-system": "^1.0.9",
     "@mui/icons-material": "^5.5.1",
     "@mui/material": "^5.2.5",
     "@mui/styles": "^5.5.1",

--- a/src/api/useMeasureServiceApi.tsx
+++ b/src/api/useMeasureServiceApi.tsx
@@ -52,7 +52,7 @@ export class MeasureServiceApi {
     }
   }
 
-  async updateMeasure(measure: Measure): Promise<void> {
+  async updateMeasure(measure: Measure): Promise<Response> {
     return await axios.put(`${this.baseUrl}/measures/${measure.id}`, measure, {
       headers: {
         Authorization: `Bearer ${this.getAccessToken()}`,

--- a/src/components/editMeasure/measureDetails/measureInformation/DeleteDialog.tsx
+++ b/src/components/editMeasure/measureDetails/measureInformation/DeleteDialog.tsx
@@ -55,7 +55,10 @@ const DeleteDialog = (props: DeleteDialogProps) => {
     >
       <div className="top-row">
         <h3>Delete Measure</h3>
-        <IconButton onClick={onClose}>
+        <IconButton
+          onClick={onClose}
+          data-testid="delete-measure-dialog-button"
+        >
           <CloseIcon />
         </IconButton>
       </div>

--- a/src/components/editMeasure/measureDetails/measureInformation/DeleteDialog.tsx
+++ b/src/components/editMeasure/measureDetails/measureInformation/DeleteDialog.tsx
@@ -1,0 +1,87 @@
+import React from "react";
+import CloseIcon from "@mui/icons-material/Close";
+import { Button } from "@madie/madie-design-system/dist/react";
+import { Dialog, IconButton, DialogActions, Divider } from "@mui/material";
+
+export interface DeleteDialogProps {
+  open: Boolean;
+  onClose: Function;
+  measureName: String;
+  deleteMeasure: Boolean;
+}
+
+const DeleteDialog = (props: DeleteDialogProps) => {
+  const { open, onClose, measureName, deleteMeasure } = props;
+  return (
+    <Dialog
+      open={open}
+      maxWidth="sm"
+      fullWidth
+      sx={{
+        display: "flex",
+        flexDirection: "column",
+        ".top-row": {
+          display: "flex",
+          flexDirection: "row",
+          flexGrow: 1,
+          justifyContent: "space-between",
+          px: 4,
+          py: 3,
+          h3: {
+            color: "#222222",
+            mb: 0,
+            mt: 1,
+          },
+          ".MuiButtonBase-root": {
+            ".MuiSvgIcon-root": {
+              color: "#242424",
+            },
+          },
+        },
+        ".message": {
+          mt: 4.5,
+          mx: 3.75,
+          mb: 12.5,
+          fontSize: 16,
+        },
+        ".MuiDialogActions-root": {
+          py: 2,
+          px: 4.25,
+          ".qpp-c-button": {
+            ml: 2.375,
+          },
+        },
+      }}
+    >
+      <div className="top-row">
+        <h3>Delete Measure</h3>
+        <IconButton onClick={onClose}>
+          <CloseIcon />
+        </IconButton>
+      </div>
+      <Divider />
+      <p className="message">
+        Are you sure you want to delete <strong>{measureName}?</strong>
+      </p>
+      <Divider />
+      <DialogActions>
+        <Button
+          variant="secondary"
+          onClick={onClose}
+          data-testid="cancel-delete-measure-button"
+        >
+          Cancel
+        </Button>
+        <Button
+          variant="danger-primary"
+          onClick={deleteMeasure}
+          data-testid="delete-measure-button-2"
+        >
+          Yes, Delete
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default DeleteDialog;

--- a/src/components/editMeasure/measureDetails/measureInformation/DeleteDialog.tsx
+++ b/src/components/editMeasure/measureDetails/measureInformation/DeleteDialog.tsx
@@ -7,7 +7,7 @@ export interface DeleteDialogProps {
   open: boolean;
   onClose: any;
   measureName: String;
-  deleteMeasure: Boolean;
+  deleteMeasure: Function;
 }
 
 const DeleteDialog = (props: DeleteDialogProps) => {

--- a/src/components/editMeasure/measureDetails/measureInformation/DeleteDialog.tsx
+++ b/src/components/editMeasure/measureDetails/measureInformation/DeleteDialog.tsx
@@ -4,8 +4,8 @@ import { Button } from "@madie/madie-design-system/dist/react";
 import { Dialog, IconButton, DialogActions, Divider } from "@mui/material";
 
 export interface DeleteDialogProps {
-  open: Boolean;
-  onClose: Function;
+  open: boolean;
+  onClose: any;
   measureName: String;
   deleteMeasure: Boolean;
 }

--- a/src/components/editMeasure/measureDetails/measureInformation/MeasureInformation.test.tsx
+++ b/src/components/editMeasure/measureDetails/measureInformation/MeasureInformation.test.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
-import { render, cleanup, fireEvent } from "@testing-library/react";
+import { render, cleanup, fireEvent, waitFor } from "@testing-library/react";
+import { act } from "react-dom/test-utils";
 import MeasureInformation from "./MeasureInformation";
 import useMeasureServiceApi, {
   MeasureServiceApi,
@@ -8,40 +9,58 @@ import useCurrentMeasure from "../../useCurrentMeasure";
 import useKeyPress from "../../../../hooks/useKeypress";
 import { MeasureContextHolder } from "../../MeasureContext";
 import Measure from "../../../../models/Measure";
+import useOktaTokens from "../../../../hooks/useOktaTokens";
+import { MemoryRouter } from "react-router";
 
+const mockHistoryPush = jest.fn();
+
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  useHistory: () => ({
+    push: mockHistoryPush,
+  }),
+}));
 jest.mock("../../../../api/useMeasureServiceApi");
 jest.mock("../../useCurrentMeasure");
 jest.mock("../../../../hooks/useKeypress");
+jest.mock("../../../../hooks/useOktaTokens");
 
 const useMeasureServiceApiMock =
   useMeasureServiceApi as jest.Mock<MeasureServiceApi>;
+
+const useOktaTokensMock = useOktaTokens as Jest.Mock<Function>;
 
 const useCurrentMeasureMock =
   useCurrentMeasure as jest.Mock<MeasureContextHolder>;
 
 const useKeypressMock = useKeyPress as jest.Mock<boolean>;
+let serviceApiMock: MeasureServiceApi;
+serviceApiMock = {
+  updateMeasure: jest
+    .fn()
+    .mockResolvedValueOnce(undefined)
+    .mockResolvedValueOnce(undefined)
+    .mockResolvedValueOnce(undefined)
+    .mockResolvedValueOnce({ status: 200 }),
+} as unknown as MeasureServiceApi;
+useMeasureServiceApiMock.mockImplementation(() => serviceApiMock);
 
 describe("MeasureInformation component", () => {
   let measure: Measure;
-  let serviceApiMock: MeasureServiceApi;
   let measureContextHolder: MeasureContextHolder;
-
   afterEach(cleanup);
 
   beforeEach(() => {
     useKeypressMock.mockReturnValue(false);
-
     measure = {
       id: "test measure",
       measureName: "the measure for testing",
+      createdBy: "testuser@example.com",
     } as Measure;
 
-    serviceApiMock = {
-      updateMeasure: jest.fn().mockResolvedValue(undefined),
-    } as unknown as MeasureServiceApi;
-
-    useMeasureServiceApiMock.mockImplementation(() => serviceApiMock);
-
+    useOktaTokensMock.mockImplementation(() => ({
+      getUserName: () => "testuser@example.com",
+    }));
     measureContextHolder = {
       measure,
       setMeasure: jest.fn(),
@@ -71,30 +90,109 @@ describe("MeasureInformation component", () => {
 
   it("should save the measure's name on an update", async () => {
     const { findByTestId, getByTestId } = render(<MeasureInformation />);
-
     // Click the name to trigger the inline edit
     const clickableSpan = getByTestId("inline-view-span");
     fireEvent.click(clickableSpan);
-
     // Have the user click enter (after input)
     useKeypressMock.mockReturnValueOnce(true);
-
     // Type in the new value
     const input = await findByTestId("inline-edit-input");
     fireEvent.change(input, {
       target: { value: "new value" },
     });
-
     // Wait for rendering
     await findByTestId("inline-view-span");
-
     // Check expectations
     const expected = {
       id: "test measure",
       measureName: "new value",
+      createdBy: "testuser@example.com",
     };
     const mockSetMeasure = measureContextHolder.setMeasure as jest.Mock<void>;
     expect(serviceApiMock.updateMeasure).toHaveBeenCalledWith(expected);
     expect(mockSetMeasure).toHaveBeenCalledWith(expected);
+  });
+
+  it("Should display a delete button if user is the owner of measure", async () => {
+    await act(async () => {
+      const { findByTestId } = render(<MeasureInformation />);
+      const result: HTMLElement = await findByTestId("delete-measure-button");
+      expect(result).toBeInTheDocument();
+    });
+  });
+
+  it("Should not display a delete button if user is not the owner of measure", async () => {
+    useOktaTokensMock.mockImplementation(() => ({
+      getUserName: () => "othertestuser@example.com",
+    }));
+    await act(async () => {
+      const { queryByText } = render(<MeasureInformation />);
+      const result: HTMLElement = queryByText("delete-measure-button");
+      expect(result).toBeNull();
+    });
+  });
+
+  it("On delete click, user is presented with a confirm deletion screen", async () => {
+    await act(async () => {
+      const { findByTestId, getByTestId } = await render(
+        <MeasureInformation />
+      );
+      const result: HTMLElement = await findByTestId("delete-measure-button");
+      fireEvent.click(result);
+      const confirmDelete = await getByTestId("delete-measure-button-2");
+      expect(confirmDelete).toBeInTheDocument();
+      const cancelDelete = await getByTestId("cancel-delete-measure-button");
+      expect(cancelDelete).toBeInTheDocument();
+    });
+  });
+
+  it("On failed delete action click, user can see toast error pop up", async () => {
+    await act(async () => {
+      const { findByTestId, getByTestId } = await render(
+        <MeasureInformation />
+      );
+      const result: HTMLElement = await findByTestId("delete-measure-button");
+      fireEvent.click(result);
+      const confirmDelete = await getByTestId("delete-measure-button-2");
+      expect(confirmDelete).toBeInTheDocument();
+      const cancelDelete = await getByTestId("cancel-delete-measure-button");
+      expect(cancelDelete).toBeInTheDocument();
+      fireEvent.click(confirmDelete);
+      await waitFor(
+        () =>
+          expect(
+            getByTestId("edit-measure-information-generic-error-text")
+          ).toBeInTheDocument(),
+        {
+          timeout: 5000,
+        }
+      );
+    });
+  });
+
+  it("On successful delete action click, user can see success message and routes back to measures", async () => {
+    await act(async () => {
+      const { findByTestId, getByTestId } = await render(
+        <MemoryRouter>
+          <MeasureInformation />
+        </MemoryRouter>
+      );
+      const result: HTMLElement = await findByTestId("delete-measure-button");
+      fireEvent.click(result);
+      const confirmDelete = await getByTestId("delete-measure-button-2");
+      expect(confirmDelete).toBeInTheDocument();
+      fireEvent.click(confirmDelete);
+      await waitFor(
+        () => {
+          expect(
+            getByTestId("edit-measure-information-success-text")
+          ).toBeInTheDocument();
+          expect(mockHistoryPush).toHaveBeenCalledWith("/measures");
+        },
+        {
+          timeout: 5000,
+        }
+      );
+    });
   });
 });

--- a/src/components/editMeasure/measureDetails/measureInformation/MeasureInformation.tsx
+++ b/src/components/editMeasure/measureDetails/measureInformation/MeasureInformation.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { useHistory } from "react-router-dom";
 import tw from "twin.macro";
 import styled, { css } from "styled-components";
 import InlineEdit from "../../../inlineEdit/InlineEdit";
@@ -6,6 +7,9 @@ import Measure from "../../../../models/Measure";
 import useMeasureServiceApi from "../../../../api/useMeasureServiceApi";
 import useCurrentMeasure from "../../useCurrentMeasure";
 import "styled-components/macro";
+import useOktaTokens from "../../../../hooks/useOktaTokens";
+import { Button, Toast } from "@madie/madie-design-system/dist/react";
+import DeleteDialog from "./DeleteDialog";
 
 export const DisplayDiv = styled.div(() => [
   tw`flex`,
@@ -18,10 +22,50 @@ export const DisplaySpan = styled.span`
 `;
 
 export default function MeasureInformation() {
+  const history = useHistory();
   const measureServiceApi = useMeasureServiceApi();
   const { measure, setMeasure } = useCurrentMeasure();
   const [genericErrorMessage, setGenericErrorMessage] = useState<string>();
+  const { getUserName } = useOktaTokens();
+  const userName = getUserName();
 
+  // Dialog and toast utilities
+  const [deleteOpen, setDeleteOpen] = useState<boolean>(false);
+  const [toastOpen, setToastOpen] = useState<boolean>(false);
+  const [toastMessage, setToastMessage] = useState<string>("");
+  const [toastType, setToastType] = useState<string>("danger");
+
+  const onToastClose = () => {
+    setToastType(null);
+    setToastMessage("");
+    setToastOpen(false);
+  };
+  const handleToast = (type, message, open) => {
+    setToastType(type);
+    setToastMessage(message);
+    setToastOpen(open);
+  };
+
+  const deleteMeasure = async () => {
+    const deletedMeasure: Measure = { ...measure, active: false };
+    try {
+      const result = await measureServiceApi.updateMeasure(deletedMeasure);
+      if (result.status === 200) {
+        handleToast("success", "Measure successfully deleted", true);
+        setTimeout(() => {
+          history.push("/measures");
+        }, 3000);
+      }
+    } catch (e) {
+      if (e?.response?.data) {
+        const { error, status, message } = e.response.data;
+        const errorMessage = `${status}: ${error} ${message}`;
+        handleToast("danger", errorMessage, true);
+      } else {
+        handleToast("danger", e.toString(), true);
+      }
+    }
+  };
   function updateMeasureTitle(text: string): void {
     if (text !== measure.measureName) {
       const newMeasure: Measure = { ...measure, measureName: text };
@@ -43,6 +87,12 @@ export default function MeasureInformation() {
 
   return (
     <div tw="px-4 pt-4" data-testid="measure-name-edit">
+      <DeleteDialog
+        open={deleteOpen}
+        onClose={() => setDeleteOpen(false)}
+        measureName={measure?.measureName}
+        deleteMeasure={deleteMeasure}
+      />
       {genericErrorMessage && (
         <div tw="bg-red-500 pt-4 px-4 pb-4">
           <span
@@ -56,11 +106,34 @@ export default function MeasureInformation() {
       <DisplayDiv>
         <span tw="mr-2">Measure Name:</span>
         <InlineEdit text={measure.measureName} onSetText={updateMeasureTitle} />
+        {measure.createdBy === userName && (
+          <Button
+            variant="danger-primary"
+            data-testid="delete-measure-button"
+            disabled={measure.createdBy !== userName}
+            onClick={() => setDeleteOpen(true)}
+          >
+            Delete Measure
+          </Button>
+        )}
       </DisplayDiv>
       <div tw="flex" data-testid="cql-library-name-display">
         <span tw="mr-2">Measure CQL Library Name:</span>
         <DisplaySpan>{measure.cqlLibraryName || "NA"}</DisplaySpan>
       </div>
+      <Toast
+        toastKey="measure-information-toast"
+        toastType={toastType}
+        testId={
+          toastType === "danger"
+            ? "edit-measure-information-generic-error-text"
+            : "edit-measure-information-success-text"
+        }
+        open={toastOpen}
+        message={toastMessage}
+        onClose={onToastClose}
+        autoHideDuration={6000}
+      />
     </div>
   );
 }

--- a/src/components/editMeasure/measureDetails/measureInformation/__snapshots__/MeasureInformation.test.tsx.snap
+++ b/src/components/editMeasure/measureDetails/measureInformation/__snapshots__/MeasureInformation.test.tsx.snap
@@ -37,6 +37,13 @@ exports[`MeasureInformation component should render the component with a blank m
         </span>
       </div>
     </div>
+    <button
+      class="qpp-c-button qpp-c-button--danger-primary"
+      data-testid="delete-measure-button"
+      type="button"
+    >
+      Delete Measure
+    </button>
   </div>
   <div
     class="MeasureInformation___StyledDiv3-sc-1pua5bc-6 ieyezC"
@@ -94,6 +101,13 @@ exports[`MeasureInformation component should render the component with measure's
         </span>
       </div>
     </div>
+    <button
+      class="qpp-c-button qpp-c-button--danger-primary"
+      data-testid="delete-measure-button"
+      type="button"
+    >
+      Delete Measure
+    </button>
   </div>
   <div
     class="MeasureInformation___StyledDiv3-sc-1pua5bc-6 ieyezC"

--- a/src/components/newMeasure/CreateNewMeasureDialog.tsx
+++ b/src/components/newMeasure/CreateNewMeasureDialog.tsx
@@ -153,6 +153,7 @@ const CreateNewMeasureDialog = ({ open, onClose }) => {
       model: "",
       cqlLibraryName: "",
       measureScoring: "",
+      active: true,
       // TO DO: validation, models for new entries
     } as Measure,
     validationSchema: MeasureSchemaValidator,

--- a/src/hooks/useOktaTokens.ts
+++ b/src/hooks/useOktaTokens.ts
@@ -28,6 +28,7 @@ const useOktaTokens = (storageKey = "okta-token-storage") => {
   return {
     getAccessToken: () => getAccessTokenObj(storageKey)?.accessToken,
     getAccessTokenObj: () => getAccessTokenObj(storageKey),
+    getUserName: () => getAccessTokenObj(storageKey).claims.sub,
     getIdToken: () => getIdTokenObj(storageKey)?.idToken,
     getIdTokenObj: () => getIdTokenObj(storageKey),
   };

--- a/src/models/Measure.ts
+++ b/src/models/Measure.ts
@@ -19,6 +19,7 @@ export interface Group {
 
 export default interface Measure {
   id: string;
+  active: boolean;
   measureHumanReadableId: string;
   measureSetId: string;
   version: number;


### PR DESCRIPTION
## MADiE PR

Jira Ticket: [MAT-3967](https://jira.cms.gov/browse/MAT-3967)

(Optional) Related Tickets:
Jira Ticket: [MAT-3967](https://jira.cms.gov/browse/MAT-4126)

<img width="815" alt="image" src="https://user-images.githubusercontent.com/84744653/162516996-a9c078a5-6761-4923-b486-9c3715408eff.png">
<img width="1004" alt="image" src="https://user-images.githubusercontent.com/84744653/162517310-1cc34096-e7c4-42a3-9f3d-23a0e2baad19.png">
<img width="929" alt="image" src="https://user-images.githubusercontent.com/84744653/162517403-9a7185dd-2599-4ca5-acfc-c4cb673f0b4e.png">

### Summary
This PR adds
- utility for retrieving logged in user through okta token
- a conditionally rendered delete measure button
- a delete measure dialog
- delete error and success handling
- some toasts

### All Submissions
* [x] This PR has the JIRA linked.
* [x] Required tests are included.
* [x] No extemporaneous files are included (i.e Complied files or testing results).
* [x] This PR is merging into the **correct branch**.
* [x] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [x] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).
* [ ] All CDN/Web dependencies are hosted internally (i.e MADiE-Root Repo).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
