### PR TITLE
Fixed the issue with value sets being skipped if oid is not valid

### DIFF
--- a/src/components/measureEditor/MeasureEditor.test.tsx
+++ b/src/components/measureEditor/MeasureEditor.test.tsx
@@ -201,7 +201,16 @@ const elmTranslationWithValueSetAndTranslationErrors: ElmTranslation = {
 const elmTranslationWithValueSets: ElmTranslation = {
   externalErrors: [],
   errorExceptions: [],
-  library: null,
+  library: {
+    annotation: null,
+    contexts: null,
+    identifier: null,
+    parameters: null,
+    schemaIdentifier: null,
+    statements: null,
+    usings: null,
+    valueSets: {},
+  },
 };
 
 const setMeasure = jest.fn();

--- a/src/components/measureEditor/MeasureEditor.tsx
+++ b/src/components/measureEditor/MeasureEditor.tsx
@@ -144,7 +144,7 @@ const MeasureEditor = () => {
   };
 
   const getOid = (valueSet: ElmValueSet): string => {
-    return valueSet.id.match(/[0-2](\.(0|[1-9][0-9]*))+/)[0];
+    return valueSet.id.split("ValueSet/")[1];
   };
 
   const getStartLine = (locator: string): number => {
@@ -269,7 +269,10 @@ const MeasureEditor = () => {
         if (!tgtValue) {
           setValuesetMsg("Please log in to UMLS!");
           window.localStorage.removeItem("TGT");
-        } else {
+        } else if (
+          translationResults.library?.valueSets ||
+          translationResults.library?.valueSets?.length > 0
+        ) {
           setValuesetMsg("Value Set is valid!");
         }
       }

--- a/src/components/measureEditor/MeasureEditor.tsx
+++ b/src/components/measureEditor/MeasureEditor.tsx
@@ -269,10 +269,7 @@ const MeasureEditor = () => {
         if (!tgtValue) {
           setValuesetMsg("Please log in to UMLS!");
           window.localStorage.removeItem("TGT");
-        } else if (
-          translationResults.library?.valueSets ||
-          translationResults.library?.valueSets?.length > 0
-        ) {
+        } else if (translationResults.library?.valueSets) {
           setValuesetMsg("Value Set is valid!");
         }
       }


### PR DESCRIPTION
## MADiE PR

Jira Ticket: [MAT-4391](https://jira.cms.gov/browse/MAT-4391)
(Optional) Related Tickets:

### Summary

- For the given scenarios in the story, the validations are skipped instead of returning back with an error. 
- When no value sets are added to the cql, the "value sets are valid" message is displayed at the bottom, so now its removed

### All Submissions
* [x] This PR has the JIRA linked.
* [x] Required tests are included.
* [x] No extemporaneous files are included (i.e Complied files or testing results).
* [x] This PR is merging into the **correct branch**.
* [x] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [x] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).
* [ ] All CDN/Web dependencies are hosted internally (i.e MADiE-Root Repo).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
