### PR TITLE
Update MP validator to have same start and end date, only owner can edit

### DIFF
--- a/src/components/editMeasure/measureDetails/measureInformation/MeasureInformation.tsx
+++ b/src/components/editMeasure/measureDetails/measureInformation/MeasureInformation.tsx
@@ -33,12 +33,6 @@ export const DisplaySpan = styled.span`
   white-space: pre;
 `;
 
-const FormErrors = styled.div(() => [
-  css`
-    max-width: fit-content;
-  `,
-]);
-
 const Form = tw.form`max-w-xl my-8`;
 const MessageDiv = tw.div`ml-3`;
 const MessageText = tw.p`text-sm font-medium`;
@@ -234,6 +228,7 @@ export default function MeasureInformation() {
           <div tw="m-5" data-testid="measurement-period-start-date">
             <LocalizationProvider dateAdapter={DateAdapter}>
               <DesktopDatePicker
+                disabled={!canEdit}
                 disableOpenPicker={true}
                 label="Start"
                 inputFormat="MM/dd/yyyy"
@@ -266,6 +261,7 @@ export default function MeasureInformation() {
           <div tw="m-5" data-testid="measurement-period-end-date">
             <LocalizationProvider dateAdapter={DateAdapter}>
               <DesktopDatePicker
+                disabled={!canEdit}
                 disableOpenPicker={true}
                 label="End"
                 inputFormat="MM/dd/yyyy"

--- a/src/models/MeasurementPeriodValidator.ts
+++ b/src/models/MeasurementPeriodValidator.ts
@@ -34,9 +34,8 @@ export const MeasurementPeriodValidator = Yup.object().shape({
     .when("measurementPeriodStart", (measurementPeriodStart, schema) => {
       if (measurementPeriodStart !== null) {
         if (!isNaN(measurementPeriodStart.getTime())) {
-          const dayAfter = new Date(measurementPeriodStart.getTime());
           return schema.min(
-            dayAfter,
+            new Date(measurementPeriodStart.getTime()),
             "Measurement period end date should be greater than or equal to measurement period start date."
           );
         }

--- a/src/models/MeasurementPeriodValidator.ts
+++ b/src/models/MeasurementPeriodValidator.ts
@@ -34,12 +34,10 @@ export const MeasurementPeriodValidator = Yup.object().shape({
     .when("measurementPeriodStart", (measurementPeriodStart, schema) => {
       if (measurementPeriodStart !== null) {
         if (!isNaN(measurementPeriodStart.getTime())) {
-          const dayAfter = new Date(
-            measurementPeriodStart.getTime() + 86400000
-          );
+          const dayAfter = new Date(measurementPeriodStart.getTime());
           return schema.min(
             dayAfter,
-            "Measurement period end date should be greater than measurement period start date."
+            "Measurement period end date should be greater than or equal to measurement period start date."
           );
         }
       }


### PR DESCRIPTION
## MADiE PR

Jira Ticket: [MAT-4314](https://jira.cms.gov/browse/MAT-4314)
(Optional) Related Tickets:

### Summary

1. Disabling the Measurement Period Date field, if the current user is not the owner.
2. Validator is updated to accept MP start and end date to be the same.

### All Submissions
* [x] This PR has the JIRA linked.
* [x] Required tests are included.
* [x] No extemporaneous files are included (i.e Complied files or testing results).
* [x] This PR is merging into the **correct branch**.
* [x] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [x] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).
* [ ] All CDN/Web dependencies are hosted internally (i.e MADiE-Root Repo).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
