### PR TITLE
MAT-4437, MAT-4436 Prevent extra useEffect calls when the editor is blank

### DIFF
--- a/src/components/measureEditor/MeasureEditor.tsx
+++ b/src/components/measureEditor/MeasureEditor.tsx
@@ -86,6 +86,8 @@ export interface CustomCqlCode extends Omit<CqlCode, "codeSystem"> {
 
 const MeasureEditor = () => {
   const { measure, setMeasure } = useCurrentMeasure();
+  // we need a variable to prevent superflous useEffect triggers
+  const [firstLoad, setFirstLoad] = useState<boolean>(true);
   const [editorVal, setEditorVal]: [string, Dispatch<SetStateAction<string>>] =
     useState("");
   const measureServiceApi = useMeasureServiceApi();
@@ -361,7 +363,8 @@ const MeasureEditor = () => {
   };
 
   useEffect(() => {
-    if (!editorVal) {
+    if (!editorVal && firstLoad) {
+      setFirstLoad(false);
       updateElmAnnotations(measure.cql).catch((err) => {
         console.error("An error occurred while translating CQL to ELM", err);
         setElmTranslationError("Unable to translate CQL to ELM!");
@@ -370,7 +373,7 @@ const MeasureEditor = () => {
       setEditorVal(measure.cql);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [editorVal]);
+  }, [editorVal, firstLoad]);
 
   return (
     <>

--- a/src/components/measureEditor/MeasureEditor.tsx
+++ b/src/components/measureEditor/MeasureEditor.tsx
@@ -86,8 +86,6 @@ export interface CustomCqlCode extends Omit<CqlCode, "codeSystem"> {
 
 const MeasureEditor = () => {
   const { measure, setMeasure } = useCurrentMeasure();
-  // we need a variable to prevent superflous useEffect triggers
-  const [firstLoad, setFirstLoad] = useState<boolean>(true);
   const [editorVal, setEditorVal]: [string, Dispatch<SetStateAction<string>>] =
     useState("");
   const measureServiceApi = useMeasureServiceApi();
@@ -363,17 +361,14 @@ const MeasureEditor = () => {
   };
 
   useEffect(() => {
-    if (!editorVal && firstLoad) {
-      setFirstLoad(false);
-      updateElmAnnotations(measure.cql).catch((err) => {
-        console.error("An error occurred while translating CQL to ELM", err);
-        setElmTranslationError("Unable to translate CQL to ELM!");
-        setElmAnnotations([]);
-      });
-      setEditorVal(measure.cql);
-    }
+    updateElmAnnotations(measure.cql).catch((err) => {
+      console.error("An error occurred while translating CQL to ELM", err);
+      setElmTranslationError("Unable to translate CQL to ELM!");
+      setElmAnnotations([]);
+    });
+    setEditorVal(measure.cql);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [editorVal, firstLoad]);
+  }, []);
 
   return (
     <>
@@ -433,5 +428,4 @@ const MeasureEditor = () => {
     </>
   );
 };
-
 export default MeasureEditor;


### PR DESCRIPTION
This PR adds a lock boolean to let editor's useEffect know when it's the first load to prevent calls to saved cql whenever it hits empty

## MADiE PR

Jira Ticket: [MAT-4437](https://jira.cms.gov/browse/MAT-4437)
Jira Ticket: [MAT-4436](https://jira.cms.gov/browse/MAT-4436)

### Summary

### All Submissions
* [x] This PR has the JIRA linked.
* [x] Required tests are included.
* [x] No extemporaneous files are included (i.e Complied files or testing results).
* [x] This PR is merging into the **correct branch**.
* [x] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [x] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).
* [ ] All CDN/Web dependencies are hosted internally (i.e MADiE-Root Repo).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
