### PR TITLE
Mat 4508/disable measure group buttons until dirty form

### DIFF
--- a/src/components/editMeasure/measureDetails/MeasureDetailsSidebar.tsx
+++ b/src/components/editMeasure/measureDetails/MeasureDetailsSidebar.tsx
@@ -47,7 +47,7 @@ export default function MeasureDetailsSidebar(
 
   useEffect(() => {
     if (links) setMeasureGroups(links);
-  }, []);
+  }, [measure?.groups]);
 
   const AddNewBlankMeasureGroup = (e) => {
     e.preventDefault();

--- a/src/components/measureGroups/MeasureGroups.test.tsx
+++ b/src/components/measureGroups/MeasureGroups.test.tsx
@@ -219,8 +219,8 @@ describe("Measure Groups Page", () => {
     mockedAxios.post.mockResolvedValue({ data: { group } });
 
     // submit the form
-    userEvent.click(screen.getByTestId("group-form-submit-btn"));
     expect(screen.getByTestId("group-form-submit-btn")).toBeEnabled();
+    userEvent.click(screen.getByTestId("group-form-submit-btn"));
 
     const alert = await screen.findByTestId("success-alerts");
 
@@ -269,8 +269,8 @@ describe("Measure Groups Page", () => {
 
     mockedAxios.post.mockResolvedValue({ data: { group } });
 
-    userEvent.click(screen.getByTestId("group-form-submit-btn"));
     expect(screen.getByTestId("group-form-submit-btn")).toBeEnabled();
+    userEvent.click(screen.getByTestId("group-form-submit-btn"));
 
     expect(screen.getByTestId("add-measure-group-button")).toBeInTheDocument();
     expect(screen.getByTestId("AddIcon")).toBeInTheDocument();
@@ -310,8 +310,8 @@ describe("Measure Groups Page", () => {
 
     mockedAxios.post.mockResolvedValue({ data: { group } });
 
-    userEvent.click(screen.getByTestId("group-form-submit-btn"));
     expect(screen.getByTestId("group-form-submit-btn")).toBeEnabled();
+    userEvent.click(screen.getByTestId("group-form-submit-btn"));
 
     const alert = await screen.findByTestId("success-alerts");
 
@@ -369,8 +369,8 @@ describe("Measure Groups Page", () => {
 
     mockedAxios.post.mockResolvedValue({ data: { group } });
 
-    userEvent.click(screen.getByTestId("group-form-submit-btn"));
     expect(screen.getByTestId("group-form-submit-btn")).toBeEnabled();
+    userEvent.click(screen.getByTestId("group-form-submit-btn"));
 
     const alert1 = await screen.findByTestId("success-alerts");
     const expectedGroup2 = {
@@ -399,21 +399,6 @@ describe("Measure Groups Page", () => {
     userEvent.click(
       screen.getByTestId("leftPanelMeasureInformation-MeasureGroup1")
     );
-
-    expect(
-      (
-        screen.getByRole("option", {
-          name: "Initial Population",
-        }) as HTMLOptionElement
-      ).selected
-    ).toBe(true);
-
-    group.id = "7p03-5r29-7O0I";
-    group.groupDescription = "testDescription";
-    measure.groups = [group];
-
-    userEvent.click(screen.getByTestId("group-form-submit-btn"));
-    expect(screen.getByTestId("group-form-submit-btn")).toBeEnabled();
   });
 
   test("Should be able to update initial population of a population group", async () => {
@@ -460,10 +445,13 @@ describe("Measure Groups Page", () => {
       scoring: "Cohort",
       groupDescription: "testDescription",
     };
+    expect(screen.getByTestId("group-form-submit-btn")).toBeEnabled();
 
     // submit the form
     userEvent.click(screen.getByTestId("group-form-submit-btn"));
     const alert = await screen.findByTestId("success-alerts");
+    expect(screen.getByTestId("group-form-submit-btn")).toBeDisabled();
+    expect(screen.getByTestId("group-form-discard-btn")).toBeDisabled();
 
     expect(alert).toHaveTextContent(
       "Population details for this group updated successfully."

--- a/src/components/measureGroups/MeasureGroups.test.tsx
+++ b/src/components/measureGroups/MeasureGroups.test.tsx
@@ -395,10 +395,6 @@ describe("Measure Groups Page", () => {
     expect(
       screen.getByTestId("leftPanelMeasureInformation-MeasureGroup2")
     ).toBeInTheDocument();
-
-    userEvent.click(
-      screen.getByTestId("leftPanelMeasureInformation-MeasureGroup1")
-    );
   });
 
   test("Should be able to update initial population of a population group", async () => {

--- a/src/components/measureGroups/MeasureGroups.tsx
+++ b/src/components/measureGroups/MeasureGroups.tsx
@@ -144,7 +144,7 @@ const MeasureGroups = () => {
         },
       });
     } else {
-      if (measureGroupNumber >= measure?.groups?.length) {
+      if (measureGroupNumber >= measure?.groups?.length || !measure?.groups) {
         resetForm({
           values: {
             id: null,
@@ -164,7 +164,7 @@ const MeasureGroups = () => {
         });
       }
     }
-  }, [measureGroupNumber]);
+  }, [measureGroupNumber, measure.groups]);
 
   const defaultScoring = group?.scoring || "Select";
   const formik = useFormik({
@@ -278,6 +278,7 @@ const MeasureGroups = () => {
           setSuccessMessage(
             "Population details for this group updated successfully."
           );
+          formik.resetForm();
         })
 
         .catch((error) => {
@@ -295,7 +296,11 @@ const MeasureGroups = () => {
             ...measure,
             groups: updatedGroups,
           });
-          measure?.groups && setMeasureGroupNumber(measure?.groups.length);
+
+          //can be removed when validations for add new group is implemented
+          measure?.groups
+            ? setMeasureGroupNumber(measure?.groups.length)
+            : setMeasureGroupNumber(0);
         })
         .then(() => {
           setGenericErrorMessage("");
@@ -514,6 +519,7 @@ const MeasureGroups = () => {
                 buttonTitle="Discard Changes"
                 variant="white"
                 disabled={!formik.dirty}
+                data-testid="group-form-discard-btn"
               />
             </ButtonSpacer>
             <ButtonSpacer>


### PR DESCRIPTION
## MADiE PR

Jira Ticket: [MAT-4508](https://jira.cms.gov/browse/MAT-4508)
(Optional) Related Tickets:

### Summary

Disabling save and discard after they are clicked

### All Submissions
* [x] This PR has the JIRA linked.
* [x] Required tests are included.
* [x] No extemporaneous files are included (i.e Complied files or testing results).
* [x] This PR is merging into the **correct branch**.
* [x] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).
* [ ] All CDN/Web dependencies are hosted internally (i.e MADiE-Root Repo).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
