### PR TITLE
MAT-4878

### DIFF
--- a/src/components/measureGroups/MeasureGroupObservation.test.tsx
+++ b/src/components/measureGroups/MeasureGroupObservation.test.tsx
@@ -163,6 +163,7 @@ describe("Measure Group Observation", () => {
         scoring={MeasureScoring.RATIO}
         elmJson={elmJson}
         population={population}
+        canEdit
       />
     );
 
@@ -390,6 +391,7 @@ describe("Measure Group Observation", () => {
         scoring={MeasureScoring.RATIO}
         elmJson={null}
         population={population}
+        canEdit
       />
     );
 
@@ -445,6 +447,7 @@ describe("Measure Group Observation", () => {
         scoring={MeasureScoring.RATIO}
         elmJson={elmJson}
         population={population}
+        canEdit
       />
     );
 

--- a/src/components/measureGroups/MeasureGroupObservation.tsx
+++ b/src/components/measureGroups/MeasureGroupObservation.tsx
@@ -11,7 +11,7 @@ import { useFormikContext } from "formik";
 import * as _ from "lodash";
 import { DSLink } from "@madie/madie-design-system/dist/react";
 
-const MeasureGroupObservation = ({ scoring, population, elmJson }) => {
+const MeasureGroupObservation = ({ scoring, population, elmJson, canEdit }) => {
   const formik = useFormikContext<any>();
   let observationName = "";
   let label = `Observation`;
@@ -46,9 +46,12 @@ const MeasureGroupObservation = ({ scoring, population, elmJson }) => {
     return null;
   }
 
+  // we either return measureObservation, or the means to create one at the moment.
+  // We want three cases, MO, add, none
   return measureObservation ? (
     <div style={style}>
       <MeasureObservationDetails
+        canEdit={canEdit}
         label={label}
         required={required}
         name={observationName}
@@ -75,24 +78,26 @@ const MeasureGroupObservation = ({ scoring, population, elmJson }) => {
     </div>
   ) : (
     <span style={style}>
-      <DSLink
-        href=""
-        onClick={(e) => {
-          e.preventDefault();
-          const newObs = {
-            id: uuidv4(),
-            criteriaReference,
-          };
-          const updatedObservations: MeasureObservation[] = formik.values
-            .measureObservations
-            ? [...formik.values.measureObservations, newObs]
-            : [newObs];
-          formik.setFieldValue("measureObservations", updatedObservations);
-        }}
-        data-testid={`add-measure-observation-${observationName}`}
-      >
-        + Add Observation
-      </DSLink>
+      {canEdit && (
+        <DSLink
+          href=""
+          onClick={(e) => {
+            e.preventDefault();
+            const newObs = {
+              id: uuidv4(),
+              criteriaReference,
+            };
+            const updatedObservations: MeasureObservation[] = formik.values
+              .measureObservations
+              ? [...formik.values.measureObservations, newObs]
+              : [newObs];
+            formik.setFieldValue("measureObservations", updatedObservations);
+          }}
+          data-testid={`add-measure-observation-${observationName}`}
+        >
+          + Add Observation
+        </DSLink>
+      )}
     </span>
   );
 };

--- a/src/components/measureGroups/MeasureGroups.tsx
+++ b/src/components/measureGroups/MeasureGroups.tsx
@@ -761,6 +761,7 @@ const MeasureGroups = () => {
                               />
                             </GridLayout>
                             <MeasureGroupObservation
+                              canEdit={canEdit}
                               scoring={formik.values.scoring}
                               population={population}
                               elmJson={measure?.elmJson}
@@ -769,6 +770,7 @@ const MeasureGroups = () => {
                         );
                       })}
                       <MeasureGroupObservation
+                        canEdit={canEdit}
                         scoring={formik.values.scoring}
                         population={null}
                         elmJson={measure?.elmJson}
@@ -817,6 +819,7 @@ const MeasureGroups = () => {
                                         )}
 
                                       <Select
+                                        readOnly={!canEdit}
                                         placeHolder={{ name: "-", value: "" }}
                                         label={`Stratification ${i + 1}`}
                                         id={`Stratification-select-${i + 1}`}
@@ -844,6 +847,7 @@ const MeasureGroups = () => {
                                     </div>
 
                                     <Select
+                                      readOnly={!canEdit}
                                       placeHolder={{ name: "-", value: "" }}
                                       label={`Association ${i + 1}`}
                                       id={`association-select-${i + 1}`}
@@ -882,6 +886,7 @@ const MeasureGroups = () => {
                                             formik.values.stratifications[i]
                                               .description
                                           }
+                                          readOnly={!canEdit}
                                           name={`stratifications[${i}].description`}
                                           id="stratification-description"
                                           autoComplete="stratification-description"
@@ -903,18 +908,20 @@ const MeasureGroups = () => {
                         <div />
                       )}
                       <div>
-                        <Row>
-                          <Button
-                            data-testid="add-strat-button"
-                            onClick={(e) => {
-                              e.preventDefault();
-                              setVisibleStrats(visibleStrats + 1);
-                              arrayHelpers.push(emptyStrat);
-                            }}
-                          >
-                            Add Stratification
-                          </Button>
-                        </Row>
+                        {canEdit && (
+                          <Row>
+                            <Button
+                              data-testid="add-strat-button"
+                              onClick={(e) => {
+                                e.preventDefault();
+                                setVisibleStrats(visibleStrats + 1);
+                                arrayHelpers.push(emptyStrat);
+                              }}
+                            >
+                              Add Stratification
+                            </Button>
+                          </Row>
+                        )}
                       </div>
                     </div>
                   )}

--- a/src/components/measureGroups/MeasureObservationDetails.test.tsx
+++ b/src/components/measureGroups/MeasureObservationDetails.test.tsx
@@ -170,6 +170,7 @@ describe("Measure Observation Details", () => {
         required={false}
         elmJson={elmJson}
         measureObservation={null}
+        canEdit
       />
     );
 
@@ -212,6 +213,7 @@ describe("Measure Observation Details", () => {
         required={false}
         elmJson={elmJson}
         measureObservation={null}
+        canEdit
       />
     );
 
@@ -234,6 +236,7 @@ describe("Measure Observation Details", () => {
         required={false}
         elmJson={null}
         measureObservation={null}
+        canEdit
       />
     );
 
@@ -260,6 +263,7 @@ describe("Measure Observation Details", () => {
         required={false}
         elmJson={null}
         measureObservation={null}
+        canEdit
       />
     );
 
@@ -300,6 +304,7 @@ describe("Measure Observation Details", () => {
         elmJson={elmJson}
         measureObservation={measureObservation}
         onChange={handleChange}
+        canEdit
       />
     );
 
@@ -349,6 +354,7 @@ describe("Measure Observation Details", () => {
         required={false}
         elmJson={elmJson}
         measureObservation={measureObservation}
+        canEdit
       />
     );
 
@@ -390,6 +396,7 @@ describe("Measure Observation Details", () => {
         elmJson={elmJson}
         measureObservation={measureObservation}
         onChange={handleChange}
+        canEdit
       />
     );
 
@@ -431,6 +438,7 @@ describe("Measure Observation Details", () => {
         required={false}
         elmJson={elmJson}
         measureObservation={measureObservation}
+        canEdit
       />
     );
     const aggregateInput = screen.getByTestId(
@@ -468,6 +476,7 @@ describe("Measure Observation Details", () => {
         measureObservation={measureObservation}
         onChange={null}
         onRemove={handleRemove}
+        canEdit
       />
     );
 

--- a/src/components/measureGroups/MeasureObservationDetails.tsx
+++ b/src/components/measureGroups/MeasureObservationDetails.tsx
@@ -30,6 +30,7 @@ export interface MeasureObservationProps {
   label?: string;
   onChange?: (measureObservation) => void;
   onRemove?: (measureObservation) => void;
+  canEdit: boolean;
 }
 
 const MeasureObservationDetails = ({
@@ -40,6 +41,7 @@ const MeasureObservationDetails = ({
   measureObservation,
   onChange,
   onRemove,
+  canEdit,
 }: MeasureObservationProps) => {
   const [cqlFunctionNames, setCqlFunctionNames] = useState([]);
 
@@ -62,6 +64,7 @@ const MeasureObservationDetails = ({
             <Select
               placeHolder={{ name: "-", value: "" }}
               required={required}
+              readOnly={!canEdit}
               label={label ? label : "Observation"}
               id={`measure-observation-${name}`}
               data-testid={`select-measure-observation-${name}`}
@@ -92,7 +95,7 @@ const MeasureObservationDetails = ({
               ]}
             />
           </Col>
-          {!required && (
+          {!required && canEdit && (
             <Col style={{ marginLeft: 10 }}>
               <DSLink
                 href=""
@@ -116,6 +119,7 @@ const MeasureObservationDetails = ({
           <Col>
             <Select
               placeHolder={{ name: "-", value: "" }}
+              readOnly={!canEdit}
               required={required}
               label="Aggregate Function"
               id={`measure-observation-aggregate-${name}`}


### PR DESCRIPTION
This PR:
Updates our inputs for stratification and population tabs, removing a user's ability to edit them by passing readOnly props based on ownership.
This PR also hides or displays the add button based on weather the user is the owner of the measure.

## MADiE PR

Jira Ticket: [MAT-4878](https://jira.cms.gov/browse/MAT-4878)
(Optional) Related Tickets:

### Summary

### All Submissions
* [x] This PR has the JIRA linked.
* [x] Required tests are included.
* [x] No extemporaneous files are included (i.e Complied files or testing results).
* [x] This PR is merging into the **correct branch**.
* [x] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [x] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).
* [ ] All CDN/Web dependencies are hosted internally (i.e MADiE-Root Repo).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
