### PR TITLE
fixed search for autocomplete caused by unique key contraint for li

### DIFF
--- a/src/components/editMeasure/measureDetails/stewardAndDevelopers/StewardAndDevelopers.tsx
+++ b/src/components/editMeasure/measureDetails/stewardAndDevelopers/StewardAndDevelopers.tsx
@@ -184,6 +184,13 @@ export default function StewardAndDevelopers() {
                   formik.setFieldValue("steward", selectedVal || "");
                 }}
                 renderInput={(params) => <TextField {...params} />}
+                renderOption={(props: any, option) => {
+                  const uniqueProps = {
+                    ...props,
+                    key: `${props.key}_${props.id}`,
+                  };
+                  return <li {...uniqueProps}>{option}</li>;
+                }}
               />
               {formik.errors["steward"] && (
                 <FormHelperText
@@ -204,17 +211,23 @@ export default function StewardAndDevelopers() {
                 options={organizations}
                 disableCloseOnSelect
                 getOptionLabel={(option) => option}
-                renderOption={(props, option, { selected }) => (
-                  <li {...props}>
-                    <Checkbox
-                      icon={icon}
-                      checkedIcon={checkedIcon}
-                      style={{ marginRight: 8 }}
-                      checked={selected}
-                    />
-                    {option}
-                  </li>
-                )}
+                renderOption={(props: any, option, { selected }) => {
+                  const uniqueProps = {
+                    ...props,
+                    key: `${props.key}_${props.id}`,
+                  };
+                  return (
+                    <li {...uniqueProps}>
+                      <Checkbox
+                        icon={icon}
+                        checkedIcon={checkedIcon}
+                        style={{ marginRight: 8 }}
+                        checked={selected}
+                      />
+                      {option}
+                    </li>
+                  );
+                }}
                 {...formik.getFieldProps("developers")}
                 sx={{
                   ...autoCompleteStyles,


### PR DESCRIPTION
## MADiE PR

Jira Ticket: [MAT-4716](https://jira.cms.gov/browse/MAT-4716)
(Optional) Related Tickets:

### Summary

Auto complete is deplucating options, as React expects options (LI elements) should be unique. So modified renderOptions by updating the to be unique. 

### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included.
* [ ] No extemporaneous files are included (i.e Complied files or testing results).
* [ ] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).
* [ ] All CDN/Web dependencies are hosted internally (i.e MADiE-Root Repo).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
