### PR TITLE
[MAT-4926, MAT-4934] 508: Associate inputs with labels and error text

### DIFF
--- a/src/components/editMeasure/measureDetails/measureInformation/MeasureInformation.tsx
+++ b/src/components/editMeasure/measureDetails/measureInformation/MeasureInformation.tsx
@@ -320,7 +320,7 @@ export default function MeasureInformation() {
                 </Box>
 
                 <Box sx={formRowGapped} data-testid="measurement-period-div">
-                  <LocalizationProvider dateAdapter={DateAdapter}>
+                  <LocalizationProvider dateAdapter={AdapterDateFns}>
                     <DesktopDatePicker
                       disableOpenPicker={true}
                       disabled={!canEdit}
@@ -340,6 +340,7 @@ export default function MeasureInformation() {
                           <TextField
                             {...formikFieldProps}
                             {...params}
+                            id="measurementPeriodStartDate"
                             required
                             data-testid="measurement-period-start"
                             helperText={formikErrorHandler(
@@ -351,7 +352,7 @@ export default function MeasureInformation() {
                       }}
                     />
                   </LocalizationProvider>
-                  <LocalizationProvider dateAdapter={DateAdapter}>
+                  <LocalizationProvider dateAdapter={AdapterDateFns}>
                     <DesktopDatePicker
                       disableOpenPicker={true}
                       disabled={!canEdit}
@@ -368,6 +369,7 @@ export default function MeasureInformation() {
                           <TextField
                             {...formikFieldProps}
                             {...params}
+                            id="measurementPeriodEndDate"
                             required
                             data-testid="measurement-period-end"
                             helperText={formikErrorHandler(

--- a/src/components/editMeasure/measureDetails/measureInformation/MeasureInformation.tsx
+++ b/src/components/editMeasure/measureDetails/measureInformation/MeasureInformation.tsx
@@ -11,9 +11,9 @@ import {
   ReadOnlyTextField,
 } from "@madie/madie-design-system/dist/react";
 import DeleteDialog from "./DeleteDialog";
-import LocalizationProvider from "@mui/lab/LocalizationProvider";
-import DateAdapter from "@mui/lab/AdapterDateFns";
-import DesktopDatePicker from "@mui/lab/DesktopDatePicker";
+import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider";
+import { AdapterDateFns } from "@mui/x-date-pickers/AdapterDateFns";
+import { DesktopDatePicker } from "@mui/x-date-pickers/DesktopDatePicker";
 import {
   DialogContent,
   DialogTitle,

--- a/src/components/measureGroups/AutoComplete.tsx
+++ b/src/components/measureGroups/AutoComplete.tsx
@@ -41,7 +41,7 @@ const AutoComplete = ({
 }) => {
   return (
     <FormControl error={error} fullWidth sx={{ paddingRight: 2 }}>
-      <InputLabel htmlFor={`${label}-dropdown`} required={required}>
+      <InputLabel htmlFor={`${id}`} required={required}>
         {label}
       </InputLabel>
       {!disabled && (

--- a/src/components/measureGroups/MeasureGroupPopulationSelect.tsx
+++ b/src/components/measureGroups/MeasureGroupPopulationSelect.tsx
@@ -117,7 +117,7 @@ const MeasureGroupPopulationSelect = ({
                 ? removeSecondIPLabelTemplate()
                 : label
             }
-            id={htmlId}
+            id={`${htmlId}-select`}
             inputProps={{
               "data-testid": `select-measure-group-population-input`,
             }}

--- a/src/components/measureGroups/MeasureGroupScoringUnit.tsx
+++ b/src/components/measureGroups/MeasureGroupScoringUnit.tsx
@@ -134,11 +134,12 @@ const MeasureGroupScoringUnit = ({
       style={{ paddingLeft: "16px" }}
     >
       <FormControl fullWidth>
-        <InputLabel htmlFor="scoring-unit-dropdown" required={false}>
+        <InputLabel id="scoring-unit-dropdown-label" required={false}>
           Scoring Unit
         </InputLabel>
         {canEdit && (
           <AsyncSelect
+            id="scoring-unit-dropdown"
             styles={customStyles}
             cacheOptions
             loadOptions={loadOptions}
@@ -150,6 +151,7 @@ const MeasureGroupScoringUnit = ({
             value={value}
             defaultInputValue={value}
             isClearable={true}
+            aria-labelledby="scoring-unit-dropdown-label"
           />
         )}
         {!canEdit && value?.label}

--- a/src/components/measureGroups/MeasureGroups.tsx
+++ b/src/components/measureGroups/MeasureGroups.tsx
@@ -899,7 +899,9 @@ const MeasureGroups = () => {
                                     </div>
                                   </div>
                                   <div tw="md:col-span-2">
-                                    <FieldLabel htmlFor="stratification-description">
+                                    <FieldLabel
+                                      htmlFor={`stratification-${i}-description`}
+                                    >
                                       Stratification {i + 1} Description
                                     </FieldLabel>
                                     <FieldSeparator>
@@ -915,7 +917,7 @@ const MeasureGroups = () => {
                                           }
                                           readOnly={!canEdit}
                                           name={`stratifications[${i}].description`}
-                                          id="stratification-description"
+                                          id={`stratification-${i}-description`}
                                           autoComplete="stratification-description"
                                           placeholder="Enter Description"
                                           data-testid="stratificationDescriptionText"

--- a/src/components/measureGroups/MultipleSelectDropDown.tsx
+++ b/src/components/measureGroups/MultipleSelectDropDown.tsx
@@ -72,27 +72,23 @@ export default function MultipleSelectDropDown(props: {
     <div>
       <FormControl fullWidth sx={{ paddingRight: 2 }}>
         <InputLabel
-          htmlFor={`${props.label}-dropdown`}
+          id={`${props.id}-label`}
+          htmlFor={props.id}
           required={props.required}
         >
           {props.label}
         </InputLabel>
         {props.canEdit && (
           <Select
+            id={props.id}
             sx={dropdownStyle}
             required
-            labelId={`${props.id}-multiple-select-dropdown`}
             data-testid={`${props.id}-dropdown`}
             multiple
             displayEmpty
             {...props.formControl}
             onChange={handleOnchange}
-            input={
-              <OutlinedInput
-                id={`${props.id}-select-multiple-dropdown`}
-                label={props.label}
-              />
-            }
+            aria-labelledby={`${props.id}-label`}
             renderValue={(selected: any) => {
               if (selected.length === 0) {
                 return <em>Select all that apply</em>;


### PR DESCRIPTION
- Switch datepickers to maintained package. In theory, there's no functionality change.
- Associate inputs with a label or provide an aria-labelledby attribute. Add aria-describedby attributes to support read out of error helper text

## MADiE PR
Jira Ticket: [MAT-4926](https://jira.cms.gov/browse/MAT-4926)
Jira Ticket: [MAT-4934](https://jira.cms.gov/browse/MAT-4934)
(Optional) Related Tickets:

### Summary
Ensure input fields are associated with their label and any error helper text.

This is accomplished either by linking the label to its input via the label's `for` attribute or by setting the `aria-labelledby` attribute on the input. OR, in the case of mui controlled inputs that are aria hidden, setting the `aria-labelledby` attribute on the parent div. 

Error helper text is associated by setting the `aria-describedby` attribute on the target element (input or parent div as needed).

### Additional Edits
Swapped the source package for the mui datepickers since the older package has been deprecated.

### All Submissions
* [x] This PR has the JIRA linked.
* [x] Required tests are included.
* [x] No extemporaneous files are included (i.e Complied files or testing results).
* [x] This PR is merging into the **correct branch**.
* [x] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [x] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).
* [ ] All CDN/Web dependencies are hosted internally (i.e MADiE-Root Repo).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
