### PR TITLE
MAT-5528 remove unnecessary trailing slashes in urls

### DIFF
--- a/src/api/useMeasureServiceApi.tsx
+++ b/src/api/useMeasureServiceApi.tsx
@@ -91,7 +91,7 @@ export class MeasureServiceApi {
   async createGroup(group: Group, measureId: string): Promise<Group> {
     try {
       const response = await axios.post<Group>(
-        `${this.baseUrl}/measures/${measureId}/groups/`,
+        `${this.baseUrl}/measures/${measureId}/groups`,
         group,
         {
           headers: {
@@ -148,7 +148,7 @@ export class MeasureServiceApi {
   async updateGroup(group: Group, measureId: string): Promise<Group> {
     try {
       const response = await axios.put<Group>(
-        `${this.baseUrl}/measures/${measureId}/groups/`,
+        `${this.baseUrl}/measures/${measureId}/groups`,
         group,
         {
           headers: {
@@ -370,7 +370,7 @@ export class MeasureServiceApi {
 
   async createVersion(id: string, versionType: string): Promise<Measure> {
     return await axios.put(
-      `${this.baseUrl}/measures/${id}/version/?versionType=${versionType}`,
+      `${this.baseUrl}/measures/${id}/version?versionType=${versionType}`,
       {},
       {
         headers: {

--- a/src/components/editMeasure/populationCriteria/groups/MeasureGroups.test.tsx
+++ b/src/components/editMeasure/populationCriteria/groups/MeasureGroups.test.tsx
@@ -347,13 +347,13 @@ describe("Measure Groups Page", () => {
       "Population details for this group saved successfully."
     );
     expect(mockedAxios.post.mock.calls[0][0]).toBe(
-      "example-service-url/measures/test-measure/groups/"
+      "example-service-url/measures/test-measure/groups"
     );
     expect(mockedAxios.post.mock.calls[0][1].groupDescription).toBe(
       "new description"
     );
     expect(mockedAxios.post).toHaveBeenCalledWith(
-      "example-service-url/measures/test-measure/groups/",
+      "example-service-url/measures/test-measure/groups",
       expect.anything(),
       expect.anything()
     );
@@ -568,10 +568,10 @@ describe("Measure Groups Page", () => {
       "Population details for this group saved successfully."
     );
     expect(mockedAxios.post.mock.calls[0][0]).toBe(
-      "example-service-url/measures/test-measure/groups/"
+      "example-service-url/measures/test-measure/groups"
     );
     expect(mockedAxios.post).toHaveBeenCalledWith(
-      "example-service-url/measures/test-measure/groups/",
+      "example-service-url/measures/test-measure/groups",
       expect.anything(),
       expect.anything()
     );
@@ -646,7 +646,7 @@ describe("Measure Groups Page", () => {
     );
     expect(mockedAxios.post).toHaveBeenNthCalledWith(
       1,
-      "example-service-url/measures/test-measure/groups/",
+      "example-service-url/measures/test-measure/groups",
       expect.anything(),
       expect.anything()
     );
@@ -712,7 +712,7 @@ describe("Measure Groups Page", () => {
     userEvent.click(screen.getByTestId("group-form-submit-btn"));
     await waitFor(() => {
       expect(mockedAxios.put).toHaveBeenCalledWith(
-        "example-service-url/measures/test-measure/groups/",
+        "example-service-url/measures/test-measure/groups",
         expectedGroup,
         expect.anything()
       );
@@ -900,7 +900,7 @@ describe("Measure Groups Page", () => {
     );
 
     expect(mockedAxios.put).toHaveBeenCalledWith(
-      "example-service-url/measures/test-measure/groups/",
+      "example-service-url/measures/test-measure/groups",
       expectedGroup,
       expect.anything()
     );
@@ -1797,20 +1797,14 @@ describe("Measure Groups Page", () => {
     );
 
     expect(mockedAxios.post.mock.calls[0][0]).toBe(
-      "example-service-url/measures/test-measure/groups/"
+      "example-service-url/measures/test-measure/groups"
     );
     expect(mockedAxios.post.mock.calls[0][1].groupDescription).toBe("");
     expect(mockedAxios.post).toHaveBeenCalledWith(
-      "example-service-url/measures/test-measure/groups/",
+      "example-service-url/measures/test-measure/groups",
       expect.anything(),
       expect.anything()
     );
-    // expect(mockedAxios.post).toHaveBeenNthCalledWith(
-    //   1,
-    //   "example-service-url/measures/test-measure/groups/",
-    //   expectedGroup,
-    //   expect.anything()
-    // );
   });
 
   test("measure observation should be included in persisted output for ratio", async () => {
@@ -1908,11 +1902,11 @@ describe("Measure Groups Page", () => {
     );
 
     expect(mockedAxios.post.mock.calls[0][0]).toBe(
-      "example-service-url/measures/test-measure/groups/"
+      "example-service-url/measures/test-measure/groups"
     );
     expect(mockedAxios.post.mock.calls[0][1].groupDescription).toBe("");
     expect(mockedAxios.post).toHaveBeenCalledWith(
-      "example-service-url/measures/test-measure/groups/",
+      "example-service-url/measures/test-measure/groups",
       expect.anything(),
       expect.anything()
     );


### PR DESCRIPTION
## MADiE PR

Jira Ticket: [MAT-5528](https://jira.cms.gov/browse/MAT-5528)
(Optional) Related Tickets:
related PR: https://github.com/MeasureAuthoringTool/measure-service/pull/318

### Summary
Spring Security 6 has depreciated the use of trailing slashes in url if the controller mapping does not have it. 
e.g. Controller method
```
@PostMapping("/measures/{measureId}/groups")
  public ResponseEntity<Group> createGroup() {...}
``` 
Earlier, the client can call the endpoint by `.../measures/{measureId}/groups/` or `.../measures/{measureId}/groups` but now can't call the same endpoint with `.../measures/{measureId}/groups/`. More on this: https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.0-Migration-Guide#spring-mvc-and-webflux-url-matching-changes 

### All Submissions
* [x] This PR has the JIRA linked.
* [x] Required tests are included.
* [x] No extemporaneous files are included (i.e Complied files or testing results).
* [x] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).
* [ ] All CDN/Web dependencies are hosted internally (i.e MADiE-Root Repo).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
