### PR TITLE
Save and Discard buttons are visible if user is cannot edit and are d…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@heroicons/react": "^1.0.5",
         "@lhncbc/ucum-lhc": "^4.1.5",
         "@madie/cql-antlr-parser": "^1.0.0",
-        "@madie/madie-design-system": "^1.0.46",
+        "@madie/madie-design-system": "^1.0.47",
         "@madie/madie-models": "^1.3.21",
         "@material-ui/core": "^4.12.4",
         "@mui/icons-material": "^5.5.1",
@@ -3308,9 +3308,9 @@
       }
     },
     "node_modules/@madie/madie-design-system": {
-      "version": "1.0.46",
-      "resolved": "https://registry.npmjs.org/@madie/madie-design-system/-/madie-design-system-1.0.46.tgz",
-      "integrity": "sha512-wSoNpSF0vos04HUw7/k59EqIS9ih77beQxR+mI4yn2w+HmtI0aGI9dQcuFyv10kpr5NeTrUXkoAVOvcYlzppnA==",
+      "version": "1.0.47",
+      "resolved": "https://registry.npmjs.org/@madie/madie-design-system/-/madie-design-system-1.0.47.tgz",
+      "integrity": "sha512-j777LCluHRsvMS/YbpTvFVnBwWFLcR40A8fRZ65d8PGtpBrt30rgLNMGJVjHRHgIIAAa+lDLWZuCai/wXBoFMw==",
       "dependencies": {
         "@cmsgov/design-system": "^5.0.2",
         "@emotion/react": "^11.8.2",
@@ -20941,9 +20941,9 @@
       }
     },
     "@madie/madie-design-system": {
-      "version": "1.0.46",
-      "resolved": "https://registry.npmjs.org/@madie/madie-design-system/-/madie-design-system-1.0.46.tgz",
-      "integrity": "sha512-wSoNpSF0vos04HUw7/k59EqIS9ih77beQxR+mI4yn2w+HmtI0aGI9dQcuFyv10kpr5NeTrUXkoAVOvcYlzppnA==",
+      "version": "1.0.47",
+      "resolved": "https://registry.npmjs.org/@madie/madie-design-system/-/madie-design-system-1.0.47.tgz",
+      "integrity": "sha512-j777LCluHRsvMS/YbpTvFVnBwWFLcR40A8fRZ65d8PGtpBrt30rgLNMGJVjHRHgIIAAa+lDLWZuCai/wXBoFMw==",
       "requires": {
         "@cmsgov/design-system": "^5.0.2",
         "@emotion/react": "^11.8.2",

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "@heroicons/react": "^1.0.5",
     "@lhncbc/ucum-lhc": "^4.1.5",
     "@madie/cql-antlr-parser": "^1.0.0",
-    "@madie/madie-design-system": "^1.0.46",
+    "@madie/madie-design-system": "^1.0.47",
     "@madie/madie-models": "^1.3.21",
     "@material-ui/core": "^4.12.4",
     "@mui/icons-material": "^5.5.1",

--- a/src/components/editMeasure/details/MetaDataWrapper.test.tsx
+++ b/src/components/editMeasure/details/MetaDataWrapper.test.tsx
@@ -24,10 +24,12 @@ describe("MetaDataWrapper", () => {
     expect(screen.getByText("MetaDataTitle")).toBeInTheDocument();
     expect(screen.getByText("Some content")).toBeInTheDocument();
 
-    const cancelButton = screen.getByTestId("cancel-button");
+    const cancelButton = screen.getByRole("button", {
+      name: "Discard Changes",
+    });
     expect(cancelButton).toBeEnabled();
 
-    const submitButton = screen.getByTestId("measure-MetaDataTitle-save");
+    const submitButton = screen.getByRole("button", { name: "Save" });
     expect(submitButton).toBeEnabled();
 
     userEvent.click(submitButton);
@@ -45,8 +47,12 @@ describe("MetaDataWrapper", () => {
     };
     render(<MetaDataWrapper {...newMetaDataProps} />);
 
-    expect(screen.getByText("Discard Changes")).toBeDisabled();
-    expect(screen.getByText("Save")).toBeDisabled();
+    expect(
+      screen.getByRole("button", {
+        name: "Discard Changes",
+      })
+    ).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
   });
 
   it("Should disable save button if the form is dirty but not valid", async () => {
@@ -58,8 +64,12 @@ describe("MetaDataWrapper", () => {
     };
     render(<MetaDataWrapper {...newMetaDataProps} />);
 
-    expect(screen.getByText("Save")).toBeDisabled();
-    expect(screen.getByText("Discard Changes")).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
+    expect(
+      screen.getByRole("button", {
+        name: "Discard Changes",
+      })
+    ).toBeEnabled();
   });
 
   it("Should disable save and discard button for a user who cannot edit", async () => {
@@ -71,7 +81,11 @@ describe("MetaDataWrapper", () => {
     };
     render(<MetaDataWrapper {...newMetaDataProps} />);
 
-    expect(screen.getByText("Discard Changes")).toBeDisabled();
-    expect(screen.getByText("Save")).toBeDisabled();
+    expect(
+      screen.getByRole("button", {
+        name: "Discard Changes",
+      })
+    ).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
   });
 });

--- a/src/components/editMeasure/details/MetaDataWrapper.tsx
+++ b/src/components/editMeasure/details/MetaDataWrapper.tsx
@@ -25,28 +25,26 @@ const MetaDataWrapper = ({
         </div>
         {children}
       </div>
-      {canEdit && (
-        <div className="form-actions">
-          <Button
-            variant="outline"
-            disabled={!dirty}
-            data-testid="cancel-button"
-            onClick={onCancel}
-            style={{ marginTop: 20, float: "right", marginRight: 32 }}
-          >
-            Discard Changes
-          </Button>
-          <Button
-            disabled={!(isValid && dirty)}
-            type="submit"
-            variant="cyan"
-            data-testid={`measure-${header}-save`}
-            style={{ marginTop: 20, float: "right" }}
-          >
-            Save
-          </Button>
-        </div>
-      )}
+      <div className="form-actions">
+        <Button
+          variant="outline"
+          disabled={!dirty || !canEdit}
+          data-testid="cancel-button"
+          onClick={onCancel}
+          style={{ marginTop: 20, float: "right", marginRight: 32 }}
+        >
+          Discard Changes
+        </Button>
+        <Button
+          disabled={!(isValid && dirty) || !canEdit}
+          type="submit"
+          variant="cyan"
+          data-testid={`measure-${header}-save`}
+          style={{ marginTop: 20, float: "right" }}
+        >
+          Save
+        </Button>
+      </div>
     </form>
   );
 };

--- a/src/components/editMeasure/populationCriteria/baseConfiguration/BaseConfiguration.tsx
+++ b/src/components/editMeasure/populationCriteria/baseConfiguration/BaseConfiguration.tsx
@@ -56,7 +56,7 @@ const BaseConfiguration = () => {
     initialValues: {
       scoring: measure?.scoring || "",
       baseConfigurationTypes: measure?.baseConfigurationTypes || [],
-      patientBasis: measure?.patientBasis || "true",
+      patientBasis: String(measure?.patientBasis) || "true",
     },
     enableReinitialize: true,
     validationSchema: QDMMeasureSchemaValidator,


### PR DESCRIPTION
…isabled

## MADiE PR

Jira Ticket: [MAT-5536](https://jira.cms.gov/browse/MAT-5536)
(Optional) Related Tickets:

### Summary

- Radio Button group disabled state is not working, so fixed it in "design systems" and pulled in the latest publish.
- Patient basis radio group is unable to read the value stored in DB, as Formik requires it to be String.
- Save and discard buttons are not displayed when the user cannot edit for MetaDataWrapper component which is used for Base configuration as well, but the requirement for this story is that these buttons are displayed, but should be disabled. 

### All Submissions
* [x] This PR has the JIRA linked.
* [x] Required tests are included.
* [x] No extemporaneous files are included (i.e Complied files or testing results).
* [x] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).
* [ ] All CDN/Web dependencies are hosted internally (i.e MADiE-Root Repo).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
