### PR TITLE
MAT-5887: add a loading spinner during the second dialog request

### DIFF
--- a/src/components/measureLanding/measureList/InvalidTestCaseDialog.tsx/InvalidTestCaseDialog.tsx
+++ b/src/components/measureLanding/measureList/InvalidTestCaseDialog.tsx/InvalidTestCaseDialog.tsx
@@ -1,5 +1,9 @@
 import React from "react";
-import { MadieDialog } from "@madie/madie-design-system/dist/react";
+import { Backdrop } from "@mui/material";
+import {
+  MadieDialog,
+  MadieSpinner,
+} from "@madie/madie-design-system/dist/react";
 import ErrorIcon from "@mui/icons-material/Error";
 
 interface InvalidTestCaseDialogProps {
@@ -7,46 +11,55 @@ interface InvalidTestCaseDialogProps {
   onClose: Function;
   onContinue: Function;
   versionType: String;
+  loading: boolean;
 }
 const InvalidTestCaseDialog = (props: InvalidTestCaseDialogProps) => {
-  const { open, onClose, onContinue, versionType } = props;
+  const { open, onClose, onContinue, versionType, loading } = props;
   return (
-    <MadieDialog
-      title="Version Measures with Invalid Test Cases?"
-      dialogProps={{
-        open: open,
-        onClose: onClose,
-        "data-testid": "invalid-test-case-dialog",
-      }}
-      cancelButtonProps={{
-        variant: "secondary",
-        onClick: onClose,
-        cancelText: "No, I want to fix my Test Cases",
-        "data-testid": "invalid-test-dialog-cancel-button",
-      }}
-      continueButtonProps={{
-        variant: "primary",
-        type: "submit",
-        "data-testid": "invalid-test-dialog-continue-button",
-        continueText: "Yes, Version My Measure",
-        onClick: () => {
-          onContinue(versionType);
-        },
-      }}
-    >
-      <div id="discard-changes-dialog-body">
-        <section className="dialog-warning-body">
-          <p>You have test cases that are invalid.</p>
-          <p className="strong">
-            Are you sure you want to version with invalid Test Cases?
-          </p>
-        </section>
-        <section className="dialog-warning-action">
-          <ErrorIcon />
-          <p>Test cases cannot be edited after being versioned.</p>
-        </section>
-      </div>
-    </MadieDialog>
+    <div>
+      <MadieDialog
+        title="Version Measures with Invalid Test Cases?"
+        dialogProps={{
+          open: open,
+          onClose: onClose,
+          "data-testid": "invalid-test-case-dialog",
+        }}
+        cancelButtonProps={{
+          variant: "secondary",
+          onClick: onClose,
+          cancelText: "No, I want to fix my Test Cases",
+          "data-testid": "invalid-test-dialog-cancel-button",
+        }}
+        continueButtonProps={{
+          variant: "primary",
+          type: "submit",
+          "data-testid": "invalid-test-dialog-continue-button",
+          continueText: "Yes, Version My Measure",
+          onClick: () => {
+            onContinue(versionType);
+          },
+        }}
+      >
+        <div id="discard-changes-dialog-body">
+          <section className="dialog-warning-body">
+            <p>You have test cases that are invalid.</p>
+            <p className="strong">
+              Are you sure you want to version with invalid Test Cases?
+            </p>
+          </section>
+          <section className="dialog-warning-action">
+            <ErrorIcon />
+            <p>Test cases cannot be edited after being versioned.</p>
+          </section>
+        </div>
+        <Backdrop
+          sx={{ color: "#fff", zIndex: (theme) => theme.zIndex.drawer + 1 }}
+          open={loading}
+        >
+          <MadieSpinner style={{ height: 50, width: 50 }} />
+        </Backdrop>
+      </MadieDialog>
+    </div>
   );
 };
 

--- a/src/components/measureLanding/measureList/MeasureList.tsx
+++ b/src/components/measureLanding/measureList/MeasureList.tsx
@@ -424,6 +424,7 @@ export default function MeasureList(props: {
   };
 
   const createVersion = (versionType: string) => {
+    setLoading(true);
     return measureServiceApi
       .createVersion(targetMeasure.current?.id, versionType)
       .then((r) => {
@@ -457,6 +458,7 @@ export default function MeasureList(props: {
       await measureServiceApi
         .checkValidVersion(targetMeasure.current?.id, versionType)
         .then(async (successResponse) => {
+          setLoading(false);
           // if we get a 202, we have invalid test cases, but no other issues so we can create it
           if (successResponse?.status === 202) {
             setVersionType(versionType);
@@ -623,6 +625,7 @@ export default function MeasureList(props: {
               onContinue={createVersion}
               onClose={handleDialogClose}
               versionType={versionType}
+              loading={loading}
             />
             <CreatVersionDialog
               open={createVersionDialog.open}


### PR DESCRIPTION
## MADiE PR

Jira Ticket: [MAT-5887](https://jira.cms.gov/browse/MAT-5887)
(Optional) Related Tickets:

### Summary

### All Submissions
* [x] This PR has the JIRA linked.
* [x] Required tests are included.
* [x] No extemporaneous files are included (i.e Complied files or testing results).
* [x] This PR is merging into the **correct branch**.
* [x] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [x] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).
* [ ] All CDN/Web dependencies are hosted internally (i.e MADiE-Root Repo).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
