### PR TITLE
[MAT-6290] Remove extra space in 'missing using stmt' error message

### DIFF
--- a/src/components/editMeasure/editor/MeasureEditor.tsx
+++ b/src/components/editMeasure/editor/MeasureEditor.tsx
@@ -286,7 +286,7 @@ const MeasureEditor = () => {
               setSuccess({
                 status: "success",
                 message:
-                  "CQL updated successfully but was missing a Using statement.  Please add in a valid model and version.",
+                  "CQL updated successfully but was missing a Using statement. Please add in a valid model and version.",
               });
             } else {
               const successMessage =

--- a/src/components/editMeasure/editor/StatusHandler.test.tsx
+++ b/src/components/editMeasure/editor/StatusHandler.test.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import StatusHandler, { transformAnnotation } from "./StatusHandler";
 
 describe("StatusHandler Component", () => {
@@ -118,7 +118,7 @@ describe("StatusHandler Component", () => {
     );
   });
 
-  it("Should display a generic success message and a using warning if a library warning exists when no error or messages present, also displays a list of annotations", () => {
+  it("Should display a generic success message and a using warning if a library warning exists when no error or messages present, also displays a list of annotations", async () => {
     const success = {
       status: "success",
       message:
@@ -137,9 +137,11 @@ describe("StatusHandler Component", () => {
     expect(getByTestId("generic-success-text-header")).toHaveTextContent(
       "Changes saved successfully but the following issues were found"
     );
-    expect(screen.getByTestId("library-warning")).toHaveTextContent(
-      success.message
-    );
+    await waitFor(() => {
+      expect(screen.getByTestId("library-warning")).toHaveTextContent(
+        success.message
+      );
+    });
     const errorsList = screen.getByTestId("generic-errors-text-list");
     expect(errorsList).toBeInTheDocument();
     expect(errorsList).toHaveTextContent(


### PR DESCRIPTION
## MADiE PR

Jira Ticket: [MAT-6290](https://jira.cms.gov/browse/MAT-6290)
(Optional) Related Tickets:

### Summary
Update the 'missing `using` statement' error message to have single space between sentences.

`StatusHelper` was already expecting a single space, so it was skipping the message since it was double spaced.

Finally, something in the rendering pipeline is collapsing sequences of whitespace. So the double spaces between the sentences rendered as a single space, anyways. This caused the unit tests to fail unless a single space was used. 

Something in the render pipeline is collapsing whitespace sequences, like double spaces between sentences. 
### All Submissions
* [x] This PR has the JIRA linked.
* [x] Required tests are included.
* [x] No extemporaneous files are included (i.e Complied files or testing results).
* [x] This PR is merging into the **correct branch**.
* [x] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [x] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).
* [ ] All CDN/Web dependencies are hosted internally (i.e MADiE-Root Repo).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
