### PR TITLE
Bug 6675/disabling the cms id for non owners

### DIFF
--- a/src/components/editMeasure/details/cmsIdentifier/CmsIdentifier.tsx
+++ b/src/components/editMeasure/details/cmsIdentifier/CmsIdentifier.tsx
@@ -7,7 +7,13 @@ import {
 } from "@madie/madie-design-system/dist/react";
 import GenerateCmsID from "../../../../icons/GenerateCmsID";
 
-export default function CmsIdentifier({ label, cmsId, model, onClick }) {
+export default function CmsIdentifier({
+  canEdit,
+  label,
+  cmsId,
+  model,
+  onClick,
+}) {
   return (
     <div
       style={{
@@ -50,6 +56,7 @@ export default function CmsIdentifier({ label, cmsId, model, onClick }) {
           </div>
 
           <Button
+            disabled={!canEdit}
             variant="secondary"
             onClick={onClick}
             data-testid="generate-cms-id-button"

--- a/src/components/editMeasure/details/measureInformation/MeasureInformation.tsx
+++ b/src/components/editMeasure/details/measureInformation/MeasureInformation.tsx
@@ -432,6 +432,7 @@ export default function MeasureInformation(props: MeasureInformationProps) {
           />
           {featureFlags.generateCMSID ? (
             <CmsIdentifier
+              canEdit={canEdit}
               label="CMS ID"
               cmsId={measure?.measureSet?.cmsId}
               model={measure?.model}


### PR DESCRIPTION
## MADiE PR

Jira Ticket: [MAT-6675](https://jira.cms.gov/browse/MAT-6675)
(Optional) Related Tickets:

### Summary
disabling the cms id for non owners

### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included.
* [ ] No extemporaneous files are included (i.e Complied files or testing results).
* [ ] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).
* [ ] All CDN/Web dependencies are hosted internally (i.e MADiE-Root Repo).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
