### PR TITLE
MAT-6887: updates indicate to user if measure export was freshly gene…

### DIFF
--- a/src/api/MeasureServiceApi.test.ts
+++ b/src/api/MeasureServiceApi.test.ts
@@ -387,7 +387,7 @@ describe("MeasureServiceApi Tests", () => {
       new AbortController().signal
     );
     expect(mockedAxios.get).toBeCalledTimes(1);
-    expect(measureExportData).toEqual({status: 200, data: zippedMeasureData});
+    expect(measureExportData).toEqual({ status: 200, data: zippedMeasureData });
   });
 
   it("test getMeasureExport failure", async () => {

--- a/src/api/MeasureServiceApi.test.ts
+++ b/src/api/MeasureServiceApi.test.ts
@@ -1,6 +1,6 @@
 import { MeasureServiceApi } from "./useMeasureServiceApi";
 import { libraryElm } from "./__mocks__/cqlLibraryElm";
-import axios from "axios";
+import axios, { AxiosResponse } from "axios";
 jest.mock("axios");
 const mockedAxios = axios as jest.Mocked<typeof axios>;
 import {
@@ -34,10 +34,10 @@ describe("MeasureServiceApi Tests", () => {
         measureName: "measure - C",
       } as Measure,
     ];
-    const resp = { status: 200, data: measures };
+    const resp: any = { status: 200, data: measures };
     mockedAxios.get.mockResolvedValue(resp);
 
-    const measuresList = await measureServiceApi.fetchMeasures(true, 25, 0);
+    const measuresList = await measureServiceApi.fetchMeasures(true, 25, 0, {});
     expect(mockedAxios.get).toBeCalledTimes(1);
     expect(measuresList).toEqual(measures);
   });
@@ -60,7 +60,7 @@ describe("MeasureServiceApi Tests", () => {
   });
 
   it("test fetchMeasures cancels", async () => {
-    const resp = {
+    const resp: any = {
       status: 500,
       data: "failure",
       message: "canceled",
@@ -85,7 +85,7 @@ describe("MeasureServiceApi Tests", () => {
       id: "1234AFDE",
       measureName: "measure - A",
     } as Measure;
-    const resp = { status: 200, data: measure };
+    const resp: any = { status: 200, data: measure };
     mockedAxios.get.mockResolvedValue(resp);
 
     const measuresList = await measureServiceApi.fetchMeasure("1234AFDE");
@@ -130,7 +130,7 @@ describe("MeasureServiceApi Tests", () => {
   });
 
   it("fetches measure draft statuses", async () => {
-    const resp = {
+    const resp: any = {
       status: 200,
       data: {
         aaaaa: true,
@@ -185,7 +185,7 @@ describe("MeasureServiceApi Tests", () => {
   });
 
   it("build error message from server side error response", () => {
-    const errorResponse = {
+    const errorResponse: any = {
       response: {
         status: 400,
         data: {
@@ -223,7 +223,7 @@ describe("MeasureServiceApi Tests", () => {
         measureName: "measure - C",
       } as Measure,
     ];
-    const resp = { status: 200, data: measures };
+    const resp: any = { status: 200, data: measures };
     mockedAxios.get.mockResolvedValue(resp);
 
     const measuresList =
@@ -298,7 +298,7 @@ describe("MeasureServiceApi Tests", () => {
         oid: "testOid1",
       },
     ];
-    const resp = { status: 200, data: organizations };
+    const resp: any = { status: 200, data: organizations };
     mockedAxios.get.mockResolvedValueOnce(resp);
 
     const returnedOrgList = measureServiceApi.getAllOrganizations();
@@ -320,7 +320,7 @@ describe("MeasureServiceApi Tests", () => {
   });
 
   it("test getAllOrganizations error when returned list is empty", async () => {
-    const resp = { status: 200, data: [] };
+    const resp: any = { status: 200, data: [] };
     mockedAxios.get.mockResolvedValueOnce(resp);
 
     try {
@@ -332,7 +332,7 @@ describe("MeasureServiceApi Tests", () => {
   });
 
   it("test checkValidVersion success", async () => {
-    const resp = { status: 200 };
+    const resp: any = { status: 200 };
     mockedAxios.get.mockResolvedValue(resp);
 
     await measureServiceApi.checkValidVersion("testId", "MAJOR");
@@ -348,7 +348,7 @@ describe("MeasureServiceApi Tests", () => {
       revisionNumber: 1,
     } as unknown as Measure;
 
-    const resp = { status: 200, data: measure };
+    const resp: any = { status: 200, data: measure };
     mockedAxios.put.mockResolvedValue(resp);
 
     await measureServiceApi.createVersion("testId", "MAJOR");
@@ -362,7 +362,7 @@ describe("MeasureServiceApi Tests", () => {
       measureName: "Measure - A",
     } as unknown as Measure;
 
-    const resp = { status: 200, data: measure };
+    const resp: any = { status: 200, data: measure };
     mockedAxios.post.mockResolvedValue(resp);
 
     await measureServiceApi.draftMeasure(
@@ -379,7 +379,7 @@ describe("MeasureServiceApi Tests", () => {
       size: 635581,
       type: "application/octet-stream",
     };
-    const resp = { status: 200, data: zippedMeasureData };
+    const resp: any = { status: 200, data: zippedMeasureData };
     mockedAxios.get.mockResolvedValue(resp);
 
     const measureExportData = await measureServiceApi.getMeasureExport(
@@ -414,7 +414,7 @@ describe("MeasureServiceApi Tests", () => {
         endorserOrganization: "test organization 1",
       },
     ];
-    const resp = { status: 200, data: endorsers };
+    const resp: any = { status: 200, data: endorsers };
     mockedAxios.get.mockResolvedValueOnce(resp);
 
     const returnedOrgList = measureServiceApi.getAllEndorsers();
@@ -436,7 +436,7 @@ describe("MeasureServiceApi Tests", () => {
   });
 
   it("test getAllEndorsers error when returned list is empty", async () => {
-    const resp = { status: 200, data: [] };
+    const resp: any = { status: 200, data: [] };
     mockedAxios.get.mockResolvedValueOnce(resp);
 
     try {
@@ -448,7 +448,7 @@ describe("MeasureServiceApi Tests", () => {
   });
 
   it("test createCmsId success", async () => {
-    const resp = { status: 200, data: 2 };
+    const resp: any = { status: 200, data: 2 };
     mockedAxios.put.mockResolvedValue(resp);
 
     await measureServiceApi.createCmsId("testMeasureSetId");

--- a/src/api/MeasureServiceApi.test.ts
+++ b/src/api/MeasureServiceApi.test.ts
@@ -387,7 +387,7 @@ describe("MeasureServiceApi Tests", () => {
       new AbortController().signal
     );
     expect(mockedAxios.get).toBeCalledTimes(1);
-    expect(measureExportData).toEqual(zippedMeasureData);
+    expect(measureExportData).toEqual({status: 200, data: zippedMeasureData});
   });
 
   it("test getMeasureExport failure", async () => {

--- a/src/api/useMeasureServiceApi.tsx
+++ b/src/api/useMeasureServiceApi.tsx
@@ -423,7 +423,7 @@ export class MeasureServiceApi {
   }
 
   // add abort signal.
-  async getMeasureExport(measureId: string, signal): Promise<Blob> {
+  async getMeasureExport(measureId: string, signal): Promise<any> {
     const response = await axios.get(
       `${this.baseUrl}/measures/${measureId}/exports`,
       {
@@ -434,7 +434,13 @@ export class MeasureServiceApi {
         signal,
       }
     );
-    return response.data;
+
+    console.log("response: ", response);
+    return {
+      status: response.status,
+      data: response.data,
+    };
+    // return response.data;
   }
 
   async draftMeasure(

--- a/src/api/useMeasureServiceApi.tsx
+++ b/src/api/useMeasureServiceApi.tsx
@@ -435,12 +435,10 @@ export class MeasureServiceApi {
       }
     );
 
-    console.log("response: ", response);
     return {
       status: response.status,
       data: response.data,
     };
-    // return response.data;
   }
 
   async draftMeasure(

--- a/src/api/useMeasureServiceApi.tsx
+++ b/src/api/useMeasureServiceApi.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import axios from "axios";
+import axios, { AxiosResponse } from "axios";
 import useServiceConfig from "./useServiceConfig";
 import { ServiceConfig } from "./ServiceContext";
 import {
@@ -423,22 +423,14 @@ export class MeasureServiceApi {
   }
 
   // add abort signal.
-  async getMeasureExport(measureId: string, signal): Promise<any> {
-    const response = await axios.get(
-      `${this.baseUrl}/measures/${measureId}/exports`,
-      {
-        headers: {
-          Authorization: `Bearer ${this.getAccessToken()}`,
-        },
-        responseType: "blob",
-        signal,
-      }
-    );
-
-    return {
-      status: response.status,
-      data: response.data,
-    };
+  async getMeasureExport(measureId: string, signal): Promise<AxiosResponse> {
+    return await axios.get(`${this.baseUrl}/measures/${measureId}/exports`, {
+      headers: {
+        Authorization: `Bearer ${this.getAccessToken()}`,
+      },
+      responseType: "blob",
+      signal,
+    });
   }
 
   async draftMeasure(

--- a/src/components/editMeasure/details/measureInformation/MeasureInformation.test.tsx
+++ b/src/components/editMeasure/details/measureInformation/MeasureInformation.test.tsx
@@ -387,11 +387,8 @@ describe("MeasureInformation component", () => {
       measureSetId: "testMeasureId",
       owner: "test.com",
     };
-    const byTestId = screen.getByTestId(
-      "edit-measure-information-generic-error-text"
-    );
     expect(
-      await screen.findByText("Failed to create CMS ID!")
+      await screen.findByText("Failed to create CMS ID.")
     ).toBeInTheDocument();
   });
 

--- a/src/components/editMeasure/details/measureInformation/MeasureInformation.test.tsx
+++ b/src/components/editMeasure/details/measureInformation/MeasureInformation.test.tsx
@@ -368,18 +368,14 @@ describe("MeasureInformation component", () => {
     };
 
     render(<MeasureInformation setErrorMessage={setErrorMessage} />);
-    const result: HTMLElement = getByTestId("measure-information-form");
+    const result: HTMLElement = screen.getByTestId("measure-information-form");
     expect(result).toBeInTheDocument();
 
-    await act(async () => {
-      const cmsIdBtn = getByTestId(
-        "generate-cms-id-button"
-      ) as HTMLInputElement;
-      expect(cmsIdBtn).toBeEnabled();
-      act(() => {
-        fireEvent.click(cmsIdBtn);
-      });
-    });
+    const cmsIdBtn = screen.getByTestId(
+      "generate-cms-id-button"
+    ) as HTMLInputElement;
+    expect(cmsIdBtn).toBeEnabled();
+    userEvent.click(cmsIdBtn);
 
     measure.model = Model.QDM_5_6;
     measure.measureSet = {

--- a/src/components/editMeasure/details/measureInformation/MeasureInformation.tsx
+++ b/src/components/editMeasure/details/measureInformation/MeasureInformation.tsx
@@ -311,7 +311,7 @@ export default function MeasureInformation(props: MeasureInformationProps) {
       };
       updateMeasure(newMeasure);
     } catch (error) {
-      handleToast("danger", "Failed to create CMS ID!", true);
+      handleToast("danger", "Failed to create CMS ID.", true);
     }
   };
 

--- a/src/components/editMeasure/details/measureInformation/MeasureInformation.tsx
+++ b/src/components/editMeasure/details/measureInformation/MeasureInformation.tsx
@@ -298,15 +298,19 @@ export default function MeasureInformation(props: MeasureInformationProps) {
   };
 
   const createCmsId = async (measureSetId: string) => {
-    const updatedMeasureSet = await measureServiceApi.createCmsId(measureSetId);
-    const newMeasure: Measure = {
-      ...measure,
-      measureSet: {
-        ...measure?.measureSet,
-        cmsId: updatedMeasureSet.cmsId,
-      },
-    };
-    updateMeasure(newMeasure);
+    try {
+      const updatedMeasureSet = await measureServiceApi.createCmsId(measureSetId);
+      const newMeasure: Measure = {
+        ...measure,
+        measureSet: {
+          ...measure?.measureSet,
+          cmsId: updatedMeasureSet.cmsId,
+        },
+      };
+      updateMeasure(newMeasure);
+    } catch (error) {
+      handleToast("danger", "Failed to create CMS ID!", true);
+    }
   };
 
   return (

--- a/src/components/editMeasure/details/measureInformation/MeasureInformation.tsx
+++ b/src/components/editMeasure/details/measureInformation/MeasureInformation.tsx
@@ -299,7 +299,9 @@ export default function MeasureInformation(props: MeasureInformationProps) {
 
   const createCmsId = async (measureSetId: string) => {
     try {
-      const updatedMeasureSet = await measureServiceApi.createCmsId(measureSetId);
+      const updatedMeasureSet = await measureServiceApi.createCmsId(
+        measureSetId
+      );
       const newMeasure: Measure = {
         ...measure,
         measureSet: {

--- a/src/components/measureLanding/measureList/MeasureList.tsx
+++ b/src/components/measureLanding/measureList/MeasureList.tsx
@@ -23,6 +23,7 @@ import versionErrorHelper from "../../../utils/versionErrorHelper";
 import getModelFamily from "../../../utils/measureModelHelpers";
 import _ from "lodash";
 import ExportDialog from "./exportDialog/ExportDialog";
+import { AxiosResponse } from "axios";
 
 const searchInputStyle = {
   borderRadius: "3px",
@@ -338,14 +339,14 @@ export default function MeasureList(props: {
       // we need to generate an abort controller for this call and bind it in the context of our ref
       abortController.current = new AbortController();
       const { ecqmTitle, model, version } = targetMeasure?.current ?? {};
-      const responseObj = await measureServiceApi?.getMeasureExport(
+      const { status, data } = await measureServiceApi?.getMeasureExport(
         targetMeasure.current?.id,
         abortController.current.signal
       );
+
       const warn =
-        responseObj.status === 201 &&
-        !targetMeasure?.current?.measureMetaData?.draft;
-      downloadZipFile(responseObj.data, ecqmTitle, model, version, warn);
+        status === 201 && !targetMeasure?.current?.measureMetaData?.draft;
+      downloadZipFile(data, ecqmTitle, model, version, warn);
     } catch (err) {
       const errorStatus = err.response?.status;
       const targetedMeasure = targetMeasure.current;

--- a/src/components/measureLanding/measureList/MeasureList.tsx
+++ b/src/components/measureLanding/measureList/MeasureList.tsx
@@ -304,7 +304,7 @@ export default function MeasureList(props: {
   // Ref required or value will be lost on all state changes.
   const abortController = useRef(null);
 
-  const downloadZipFile = (exportData, ecqmTitle, model, version) => {
+  const downloadZipFile = (exportData, ecqmTitle, model, version, warn=false) => {
     const url = window.URL.createObjectURL(exportData);
     const link = document.createElement("a");
     link.href = url;
@@ -317,7 +317,7 @@ export default function MeasureList(props: {
     setToastOpen(true);
     setToastType("success");
     setToastMessage("Measure exported successfully");
-    setDownloadState("success");
+    setDownloadState(warn ? "warning" : "success");
     document.body.removeChild(link);
   };
 
@@ -328,11 +328,12 @@ export default function MeasureList(props: {
       // we need to generate an abort controller for this call and bind it in the context of our ref
       abortController.current = new AbortController();
       const { ecqmTitle, model, version } = targetMeasure?.current ?? {};
-      const exportData = await measureServiceApi?.getMeasureExport(
+      const responseObj = await measureServiceApi?.getMeasureExport(
         targetMeasure.current?.id,
         abortController.current.signal
       );
-      downloadZipFile(exportData, ecqmTitle, model, version);
+      const warn = responseObj.status === 201 && !targetMeasure?.current?.measureMetaData?.draft;
+      downloadZipFile(responseObj.data, ecqmTitle, model, version, warn);
     } catch (err) {
       const errorStatus = err.response?.status;
       const targetedMeasure = targetMeasure.current;

--- a/src/components/measureLanding/measureList/MeasureList.tsx
+++ b/src/components/measureLanding/measureList/MeasureList.tsx
@@ -308,7 +308,13 @@ export default function MeasureList(props: {
   // Ref required or value will be lost on all state changes.
   const abortController = useRef(null);
 
-  const downloadZipFile = (exportData, ecqmTitle, model, version, warn=false) => {
+  const downloadZipFile = (
+    exportData,
+    ecqmTitle,
+    model,
+    version,
+    warn = false
+  ) => {
     const url = window.URL.createObjectURL(exportData);
     const link = document.createElement("a");
     link.href = url;
@@ -336,7 +342,9 @@ export default function MeasureList(props: {
         targetMeasure.current?.id,
         abortController.current.signal
       );
-      const warn = responseObj.status === 201 && !targetMeasure?.current?.measureMetaData?.draft;
+      const warn =
+        responseObj.status === 201 &&
+        !targetMeasure?.current?.measureMetaData?.draft;
       downloadZipFile(responseObj.data, ecqmTitle, model, version, warn);
     } catch (err) {
       const errorStatus = err.response?.status;

--- a/src/components/measureLanding/measureList/exportDialog/ExportDialog.tsx
+++ b/src/components/measureLanding/measureList/exportDialog/ExportDialog.tsx
@@ -25,11 +25,13 @@ const ExportDialog = ({
   const headerMap = {
     downloading: "Exporting",
     success: "Success",
+    warning: "Success",
     failure: "We're sorry!",
   };
   const messageMap = {
     downloading: <span>Please wait! this shouldn't take long.</span>,
     success: <span>Your download has been completed</span>,
+    warning: <span>Your download has been completed using the latest translator version instead of the version used at the time the measure was versioned.</span>,
     failure: (
       <span>
         Your download could <b>not</b> be completed
@@ -109,7 +111,7 @@ const ExportDialog = ({
           },
         }}
       >
-        {downloadState === "success" && (
+        {(downloadState === "success" || downloadState === "warning") && (
           <Button
             onClick={handleContinueDialog}
             variant="primary"

--- a/src/components/measureLanding/measureList/exportDialog/ExportDialog.tsx
+++ b/src/components/measureLanding/measureList/exportDialog/ExportDialog.tsx
@@ -31,7 +31,12 @@ const ExportDialog = ({
   const messageMap = {
     downloading: <span>Please wait! this shouldn't take long.</span>,
     success: <span>Your download has been completed</span>,
-    warning: <span>Your download has been completed using the latest translator version instead of the version used at the time the measure was versioned.</span>,
+    warning: (
+      <span>
+        Your download has been completed using the latest translator version
+        instead of the version used at the time the measure was versioned.
+      </span>
+    ),
     failure: (
       <span>
         Your download could <b>not</b> be completed

--- a/src/components/measureLanding/measureList/exportDialog/ExportIcon.tsx
+++ b/src/components/measureLanding/measureList/exportDialog/ExportIcon.tsx
@@ -13,7 +13,7 @@ const ExportIcon = (props: { downloadState: string }) => {
     />
   );
 
-  if (downloadState === "success") {
+  if (downloadState === "success" || downloadState === "warning") {
     content = (
       <CheckCircleOutlineIcon
         sx={{ height: "40px", width: "40px", color: "#4D7E23" }}


### PR DESCRIPTION
…rated using latest translator, or if it was pulled from storage, based on response code of export API (200 = storage, 201 = newly created)

## MADiE PR

Jira Ticket: [MAT-6887](https://jira.cms.gov/browse/MAT-6887)
(Optional) Related Tickets:
[MAT-7011](https://jira.cms.gov/browse/MAT-7011) - Access Control Weakness - CMS ID generation

### Summary
For a versioned QDM measure, if no export exists, the backend will now generate the export using the latest version of the translator. This will be indicated to users with a different message:
![image](https://github.com/MeasureAuthoringTool/madie-measure/assets/94391996/5e7942fb-6499-45ce-bd49-1be5f40adb44)

For CMS ID generation, catch the exception case and display a toast to users to indicate something went wrong:
![image](https://github.com/MeasureAuthoringTool/madie-measure/assets/94391996/56bce6cf-d820-460c-bdc3-319583e5aca5)


### All Submissions
* [x] This PR has the JIRA linked.
* [x] Required tests are included.
* [x] No extemporaneous files are included (i.e Complied files or testing results).
* [x] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).
* [ ] All CDN/Web dependencies are hosted internally (i.e MADiE-Root Repo).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
