### PR TITLE
MAT-7172: Fetch full measure when export returns a 409 (validation failure)

### DIFF
--- a/src/components/measureLanding/measureList/MeasureList.test.tsx
+++ b/src/components/measureLanding/measureList/MeasureList.test.tsx
@@ -1121,6 +1121,7 @@ describe("Measure List component", () => {
       return {
         ...mockMeasureServiceApi,
         getMeasureExport: jest.fn().mockRejectedValue(error),
+        fetchMeasure: jest.fn().mockResolvedValue(measures[0]),
       } as unknown as MeasureServiceApi;
     });
 
@@ -1167,6 +1168,7 @@ describe("Measure List component", () => {
       return {
         ...mockMeasureServiceApi,
         getMeasureExport: jest.fn().mockRejectedValue(error),
+        fetchMeasure: jest.fn().mockResolvedValue(measures[2]),
       } as unknown as MeasureServiceApi;
     });
 
@@ -1212,6 +1214,7 @@ describe("Measure List component", () => {
       return {
         ...mockMeasureServiceApi,
         getMeasureExport: jest.fn().mockRejectedValue(error),
+        fetchMeasure: jest.fn().mockResolvedValue(measures[2]),
       } as unknown as MeasureServiceApi;
     });
 
@@ -1261,6 +1264,7 @@ describe("Measure List component", () => {
       return {
         ...mockMeasureServiceApi,
         getMeasureExport: jest.fn().mockRejectedValue(error),
+        fetchMeasure: jest.fn().mockResolvedValue(measures[2]),
       } as unknown as MeasureServiceApi;
     });
 
@@ -1311,6 +1315,7 @@ describe("Measure List component", () => {
       return {
         ...mockMeasureServiceApi,
         getMeasureExport: jest.fn().mockRejectedValue(error),
+        fetchMeasure: jest.fn().mockResolvedValue(measures[3]),
       } as unknown as MeasureServiceApi;
     });
 
@@ -1358,6 +1363,7 @@ describe("Measure List component", () => {
       return {
         ...mockMeasureServiceApi,
         getMeasureExport: jest.fn().mockRejectedValue(error),
+        fetchMeasure: jest.fn().mockResolvedValue(measures[1]),
       } as unknown as MeasureServiceApi;
     });
 
@@ -1403,6 +1409,7 @@ describe("Measure List component", () => {
       return {
         ...mockMeasureServiceApi,
         getMeasureExport: jest.fn().mockRejectedValue(error),
+        fetchMeasure: jest.fn().mockResolvedValue(measures[2]),
       } as unknown as MeasureServiceApi;
     });
 
@@ -1447,6 +1454,7 @@ describe("Measure List component", () => {
       return {
         ...mockMeasureServiceApi,
         getMeasureExport: jest.fn().mockRejectedValue(error),
+        fetchMeasure: jest.fn().mockResolvedValue(measures[2]),
       } as unknown as MeasureServiceApi;
     });
 

--- a/src/components/measureLanding/measureList/MeasureList.tsx
+++ b/src/components/measureLanding/measureList/MeasureList.tsx
@@ -357,34 +357,43 @@ export default function MeasureList(props: {
         setToastType("danger");
         setDownloadState("failure");
         if (errorStatus === 409) {
+          const {
+            cql,
+            cqlErrors,
+            errors,
+            groups,
+            measureMetaData,
+            model,
+            baseConfigurationTypes,
+          } = await measureServiceApi?.fetchMeasure(targetMeasure.current?.id);
           const missing = [];
-          if (_.isEmpty(targetMeasure.current?.cql)) {
+          if (_.isEmpty(cql)) {
             missing.push("Missing CQL");
           }
-          if (targetedMeasure?.cqlErrors) {
+          if (cqlErrors) {
             missing.push("CQL Contains Errors");
           }
-          if (!_.isEmpty(targetedMeasure?.errors)) {
+          if (!_.isEmpty(errors)) {
             targetedMeasure?.errors.forEach((error) => {
               missing.push(error);
             });
           }
-          if (_.isEmpty(targetedMeasure?.groups)) {
+          if (_.isEmpty(groups)) {
             missing.push("Missing Population Criteria");
           }
-          if (_.isEmpty(targetedMeasure?.measureMetaData.developers)) {
+          if (_.isEmpty(measureMetaData.developers)) {
             missing.push("Missing Measure Developers");
           }
-          if (_.isEmpty(targetedMeasure?.measureMetaData.steward)) {
+          if (_.isEmpty(measureMetaData.steward)) {
             missing.push("Missing Steward");
           }
-          if (_.isEmpty(targetedMeasure?.measureMetaData.description)) {
+          if (_.isEmpty(measureMetaData.description)) {
             missing.push("Missing Description");
           }
           if (
-            targetedMeasure?.model === Model.QICORE &&
-            targetedMeasure.groups &&
-            targetedMeasure.groups.filter(
+            model === Model.QICORE &&
+            groups &&
+            groups.filter(
               (group) =>
                 group.measureGroupTypes === null ||
                 _.isEmpty(group.measureGroupTypes)
@@ -392,10 +401,7 @@ export default function MeasureList(props: {
           ) {
             missing.push("At least one Population Criteria is missing Type");
           }
-          if (
-            targetedMeasure?.model === Model.QDM_5_6 &&
-            _.isEmpty(targetedMeasure?.baseConfigurationTypes)
-          ) {
+          if (model === Model.QDM_5_6 && _.isEmpty(baseConfigurationTypes)) {
             missing.push("Measure Type is required");
           }
           if (missing.length <= 0) {


### PR DESCRIPTION
## MADiE PR

Jira Ticket: [MAT-7172](https://jira.cms.gov/browse/MAT-7172)
(Optional) Related Tickets:

### Summary

Fetch full measure when export returns a 409 (validation failure). This will ensure the UI export validations have the necessary measure data to correctly determine which properties are missing.

### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included.
* [ ] No extemporaneous files are included (i.e Complied files or testing results).
* [ ] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).
* [ ] All CDN/Web dependencies are hosted internally (i.e MADiE-Root Repo).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
