### PR TITLE
MAT-7179: Trigger formik validation onLoad

### DIFF
--- a/src/components/editMeasure/details/measureInformation/MeasureInformation.test.tsx
+++ b/src/components/editMeasure/details/measureInformation/MeasureInformation.test.tsx
@@ -33,8 +33,8 @@ const setErrorMessage = jest.fn();
 const testUser = "john doe";
 const measure = {
   id: "test measure",
-  measureName: "the measure for testing",
-  cqlLibraryName: "TestCqlLibraryName",
+  measureName: "TestM123",
+  cqlLibraryName: "TestLibray123",
   model: "QI-Core v4.1.1",
   ecqmTitle: "ecqmTitle",
   measurementPeriodStart: "01/01/2022",
@@ -173,6 +173,51 @@ describe("MeasureInformation component", () => {
         expect(
           screen.getByText("Endorser Number is Required")
         ).toBeInTheDocument();
+      });
+    });
+  });
+
+  test("Click Save button will save the change", async () => {
+    (checkUserCanEdit as jest.Mock).mockImplementation(() => {
+      return true;
+    });
+    render(<MeasureInformation setErrorMessage={setErrorMessage} />);
+
+    const endorserAutoComplete = await screen.findByTestId("endorser");
+    const endorserId = getByTestId(
+      "endorsement-number-input"
+    ) as HTMLInputElement;
+
+    fireEvent.keyDown(endorserAutoComplete, { key: "ArrowDown" });
+    // selects 2nd option
+    const endorserOptions = await screen.findAllByRole("option");
+    fireEvent.click(endorserOptions[1]);
+
+    // verifies if the option is selected
+    const endorserComboBox = within(endorserAutoComplete).getByRole("combobox");
+    expect(endorserComboBox).toHaveValue("NQF");
+    //verifies endorserId was enabled
+    expect(endorserId).toBeEnabled();
+    //enter endorserId
+    fireEvent.change(endorserId, {
+      target: { value: "1" },
+    });
+    expect(endorserId).toHaveValue("1");
+
+    const discardButton = screen.getByRole("button", {
+      name: "Discard Changes",
+    }) as HTMLButtonElement;
+    expect(discardButton).toBeEnabled();
+
+    await act(async () => {
+      const input = await findByTestId("measure-name-input");
+      fireEvent.change(input, {
+        target: { value: "new value" },
+      });
+      const createBtn = getByTestId("measurement-information-save-button");
+      expect(createBtn).toBeEnabled();
+      act(() => {
+        fireEvent.click(createBtn);
       });
     });
   });
@@ -670,45 +715,7 @@ describe("MeasureInformation component", () => {
     expect(endorserComboBox).toHaveValue("");
     expect(endorserId).toHaveValue("");
   });
-  test("Click Save button will save the change", async () => {
-    (checkUserCanEdit as jest.Mock).mockImplementation(() => {
-      return true;
-    });
-    render(<MeasureInformation setErrorMessage={setErrorMessage} />);
 
-    const endorserAutoComplete = await screen.findByTestId("endorser");
-    const endorserId = getByTestId(
-      "endorsement-number-input"
-    ) as HTMLInputElement;
-
-    fireEvent.keyDown(endorserAutoComplete, { key: "ArrowDown" });
-    // selects 2nd option
-    const endorserOptions = await screen.findAllByRole("option");
-    fireEvent.click(endorserOptions[1]);
-
-    // verifies if the option is selected
-    const endorserComboBox = within(endorserAutoComplete).getByRole("combobox");
-    expect(endorserComboBox).toHaveValue("NQF");
-    //verifies endorserId was enabled
-    expect(endorserId).toBeEnabled();
-    //enter endorserId
-    fireEvent.change(endorserId, {
-      target: { value: "1" },
-    });
-    expect(endorserId).toHaveValue("1");
-
-    const discardButton = screen.getByRole("button", {
-      name: "Discard Changes",
-    }) as HTMLButtonElement;
-    expect(discardButton).toBeEnabled();
-    const saveButton = screen.getByRole("button", {
-      name: "Save",
-    }) as HTMLButtonElement;
-    expect(saveButton).toBeEnabled();
-    act(() => {
-      fireEvent.click(saveButton);
-    });
-  });
   it("Discard dialog opens and succeeds", async () => {
     useMeasureServiceApiMock.mockImplementation(() => serviceApiMock);
     (checkUserCanEdit as jest.Mock).mockImplementation(() => {

--- a/src/components/editMeasure/details/measureInformation/MeasureInformation.tsx
+++ b/src/components/editMeasure/details/measureInformation/MeasureInformation.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useLayoutEffect } from "react";
 import { Endorsement, Measure } from "@madie/madie-models";
 import useMeasureServiceApi from "../../../../api/useMeasureServiceApi";
 import "styled-components/macro";
@@ -116,6 +116,9 @@ export default function MeasureInformation(props: MeasureInformationProps) {
   const { updateRouteHandlerState } = routeHandlerStore;
   const [discardDialogOpen, setDiscardDialogOpen] = useState(false);
 
+  useLayoutEffect(() => {
+    formik.validateForm();
+  }, [])
   useEffect(() => {
     updateRouteHandlerState({
       canTravel: !formik.dirty,
@@ -292,7 +295,7 @@ export default function MeasureInformation(props: MeasureInformationProps) {
       return `${formik.errors[name]}`;
     }
   }
-
+  console.log('formik.errors', formik.errors["measureName"])
   // we create a state to track current focus. We only display helper text on focus and remove current focus on blur
   const [focusedField, setFocusedField] = useState("");
   const onBlur = (field) => {
@@ -355,16 +358,12 @@ export default function MeasureInformation(props: MeasureInformationProps) {
               "aria-required": "true",
             }}
             helperText={
-              (formik.touched["measureName"] ||
-                focusedField === "measureName") &&
-              formikErrorHandler("measureName", true)
+              formik.errors["measureName"]
             }
             data-testid="measure-name-text-field"
             size="small"
             onKeyDown={goBackToNav}
-            error={
-              formik.touched.measureName && Boolean(formik.errors.measureName)
-            }
+            error={Boolean(formik.errors.measureName)}
             {...formik.getFieldProps("measureName")}
             onBlur={() => {
               onBlur("measureName");

--- a/src/components/editMeasure/details/measureInformation/MeasureInformation.tsx
+++ b/src/components/editMeasure/details/measureInformation/MeasureInformation.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useLayoutEffect } from "react";
+import React, { useState, useEffect } from "react";
 import { Endorsement, Measure } from "@madie/madie-models";
 import useMeasureServiceApi from "../../../../api/useMeasureServiceApi";
 import "styled-components/macro";
@@ -116,9 +116,6 @@ export default function MeasureInformation(props: MeasureInformationProps) {
   const { updateRouteHandlerState } = routeHandlerStore;
   const [discardDialogOpen, setDiscardDialogOpen] = useState(false);
 
-  useLayoutEffect(() => {
-    formik.validateForm();
-  }, [])
   useEffect(() => {
     updateRouteHandlerState({
       canTravel: !formik.dirty,
@@ -295,7 +292,13 @@ export default function MeasureInformation(props: MeasureInformationProps) {
       return `${formik.errors[name]}`;
     }
   }
-  console.log('formik.errors', formik.errors["measureName"])
+
+  useEffect(() => {
+    if (measure?.id) {
+      formik.validateForm();
+    }
+  }, [measure]);
+
   // we create a state to track current focus. We only display helper text on focus and remove current focus on blur
   const [focusedField, setFocusedField] = useState("");
   const onBlur = (field) => {
@@ -357,9 +360,7 @@ export default function MeasureInformation(props: MeasureInformationProps) {
               "data-testid": "measure-name-input",
               "aria-required": "true",
             }}
-            helperText={
-              formik.errors["measureName"]
-            }
+            helperText={formik.errors["measureName"]}
             data-testid="measure-name-text-field"
             size="small"
             onKeyDown={goBackToNav}

--- a/src/components/editMeasure/details/measureInformation/MeasureInformation.tsx
+++ b/src/components/editMeasure/details/measureInformation/MeasureInformation.tsx
@@ -360,11 +360,17 @@ export default function MeasureInformation(props: MeasureInformationProps) {
               "data-testid": "measure-name-input",
               "aria-required": "true",
             }}
-            helperText={formik.errors["measureName"]}
+            helperText={
+              (formik.touched["measureName"] ||
+                focusedField === "measureName") &&
+              formikErrorHandler("measureName", true)
+            }
             data-testid="measure-name-text-field"
             size="small"
             onKeyDown={goBackToNav}
-            error={Boolean(formik.errors.measureName)}
+            error={
+              formik.touched.measureName && Boolean(formik.errors.measureName)
+            }
             {...formik.getFieldProps("measureName")}
             onBlur={() => {
               onBlur("measureName");
@@ -382,16 +388,9 @@ export default function MeasureInformation(props: MeasureInformationProps) {
               "data-testid": "cql-library-name-input",
               "aria-required": "true",
             }}
-            helperText={
-              formik.touched["cqlLibraryName"] &&
-              focusedField === "cqlLibraryName" &&
-              formikErrorHandler("cqlLibraryName", true)
-            }
+            helperText={formik.errors["cqlLibraryName"]}
             size="small"
-            error={
-              formik.touched.cqlLibraryName &&
-              Boolean(formik.errors.cqlLibraryName)
-            }
+            error={Boolean(formik.errors.cqlLibraryName)}
             {...formik.getFieldProps("cqlLibraryName")}
             onBlur={() => {
               onBlur("cqlLibraryName");


### PR DESCRIPTION
## MADiE PR

Jira Ticket: [MAT-7179](https://jira.cms.gov/browse/MAT-7179)
(Optional) Related Tickets:

### Summary

Need to trigger validation on load for measures that already have names against the rules. just triggers validation on load, and allows helper text to be displayed for measureName without being touched or dirty.

### All Submissions
* [x] This PR has the JIRA linked.
* [x] Required tests are included.
* [x] No extemporaneous files are included (i.e Complied files or testing results).
* [x] This PR is merging into the **correct branch**.
* [x] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [x] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).
* [ ] All CDN/Web dependencies are hosted internally (i.e MADiE-Root Repo).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
