### PR TITLE
MAT-7246 QDM - Remove Value Set Versions from CQL and notify user

### DIFF
--- a/src/components/editMeasure/editor/MeasureEditor.test.tsx
+++ b/src/components/editMeasure/editor/MeasureEditor.test.tsx
@@ -70,13 +70,6 @@ jest.mock("@madie/madie-util", () => ({
 }));
 
 const MEASURE_CREATEDBY = "testuser@example.com"; //#nosec
-
-const elmTranslationWithNoErrors: ElmTranslation = {
-  externalErrors: [],
-  errorExceptions: [],
-  library: null,
-};
-
 const translationErrors = [
   {
     startLine: 4,
@@ -211,7 +204,12 @@ describe("MeasureEditor component", () => {
     (synchingEditorCqlContent as jest.Mock)
       .mockClear()
       .mockImplementation(() => {
-        return "library testCql version '0.0.000'";
+        return {
+          cql: "library testCql version '0.0.000'",
+          isLibraryStatementChanged: true,
+          isUsingStatementChanged: false,
+          isValueSetChanged: false,
+        };
       });
 
     mockedAxios.put.mockImplementation((args) => {
@@ -234,7 +232,7 @@ describe("MeasureEditor component", () => {
     await waitFor(() => {
       const successText = getByTestId("generic-success-text-header");
       expect(successText.textContent).toEqual(
-        "Changes saved successfully but the following issues were found"
+        "CQL updated successfully but the following issues were found"
       );
       expect(mockedAxios.put).toHaveBeenCalledTimes(1);
     });
@@ -251,7 +249,12 @@ describe("MeasureEditor component", () => {
     (synchingEditorCqlContent as jest.Mock)
       .mockClear()
       .mockImplementation(() => {
-        return "library testCql version '0.0.000'";
+        return {
+          cql: "library testCql version '0.0.000'",
+          isLibraryStatementChanged: true,
+          isUsingStatementChanged: false,
+          isValueSetChanged: false,
+        };
       });
 
     mockedAxios.put.mockImplementation((args) => {
@@ -279,7 +282,7 @@ describe("MeasureEditor component", () => {
     await waitFor(() => {
       const successText = getByTestId("generic-success-text-header");
       expect(successText.textContent).toEqual(
-        "Changes saved successfully but the following issues were found"
+        "CQL updated successfully but the following issues were found"
       );
       expect(mockedAxios.put).toHaveBeenCalledTimes(1);
     });
@@ -315,7 +318,12 @@ describe("MeasureEditor component", () => {
     (synchingEditorCqlContent as jest.Mock)
       .mockClear()
       .mockImplementation(() => {
-        return "library testCql version '0.0.000'";
+        return {
+          cql: "library testCql version '0.0.000'",
+          isLibraryStatementChanged: true,
+          isUsingStatementChanged: false,
+          isValueSetChanged: false,
+        };
       });
 
     isUsingEmpty.mockClear().mockImplementation(() => true);
@@ -340,7 +348,7 @@ describe("MeasureEditor component", () => {
     await waitFor(() => {
       const successText = getByTestId("generic-success-text-header");
       expect(successText.textContent).toEqual(
-        "Changes saved successfully but the following issues were found"
+        "CQL updated successfully but the following issues were found"
       );
       expect(mockedAxios.put).toHaveBeenCalledTimes(1);
     });
@@ -359,7 +367,12 @@ describe("MeasureEditor component", () => {
     (synchingEditorCqlContent as jest.Mock)
       .mockClear()
       .mockImplementation(() => {
-        return "librarydwwd Test2dvh3wd version '0.0.000'";
+        return {
+          cql: "librarydwwd Test2dvh3wd version '0.0.000'",
+          isLibraryStatementChanged: true,
+          isUsingStatementChanged: false,
+          isValueSetChanged: false,
+        };
       });
 
     const { getByTestId } = renderEditor(measure);
@@ -377,7 +390,7 @@ describe("MeasureEditor component", () => {
     await waitFor(() => {
       const successMessage = getByTestId("generic-success-text-header");
       expect(successMessage.textContent).toEqual(
-        "Changes saved successfully but the following issues were found"
+        "CQL updated successfully but the following issues were found"
       );
       expect(mockedAxios.put).toHaveBeenCalledTimes(1);
     });
@@ -400,7 +413,12 @@ describe("MeasureEditor component", () => {
     (synchingEditorCqlContent as jest.Mock)
       .mockClear()
       .mockImplementation(() => {
-        return "library AdvancedIllnessandFrailtyExclusion version '1.0.001'\nusing QI-Core version '4.1.1'";
+        return {
+          cql: "library AdvancedIllnessandFrailtyExclusion version '1.0.001'\nusing QI-Core version '4.1.1'",
+          isLibraryStatementChanged: true,
+          isUsingStatementChanged: false,
+          isValueSetChanged: false,
+        };
       });
 
     isUsingEmpty.mockClear().mockImplementation(() => false);
@@ -421,7 +439,7 @@ describe("MeasureEditor component", () => {
     const saveButton = screen.getByRole("button", { name: "Save" });
     userEvent.click(saveButton);
     const saveSuccess = await screen.findByText(
-      "CQL updated successfully! Library Statement or Using Statement were incorrect. MADiE has overwritten them to ensure proper CQL."
+      "CQL updated successfully but the following issues were found"
     );
     expect(saveSuccess).toBeInTheDocument();
     expect(mockedAxios.put).toHaveBeenCalledTimes(1);
@@ -443,7 +461,12 @@ describe("MeasureEditor component", () => {
     (synchingEditorCqlContent as jest.Mock)
       .mockClear()
       .mockImplementation(() => {
-        return "library AdvancedIllnessandFrailtyExclusion version '1.0.001'\nusing QI-Core version '4.1.1'";
+        return {
+          cql: "library AdvancedIllnessandFrailtyExclusion version '1.0.001'\nusing QI-Core version '4.1.1'",
+          isLibraryStatementChanged: true,
+          isUsingStatementChanged: true,
+          isValueSetChanged: false,
+        };
       });
 
     isUsingEmpty.mockClear().mockImplementation(() => false);
@@ -463,7 +486,7 @@ describe("MeasureEditor component", () => {
     const saveButton = screen.getByRole("button", { name: "Save" });
     userEvent.click(saveButton);
     const saveSuccess = await screen.findByText(
-      "CQL updated successfully! Library Statement or Using Statement were incorrect. MADiE has overwritten them to ensure proper CQL."
+      "CQL updated successfully but the following issues were found"
     );
     expect(saveSuccess).toBeInTheDocument();
     expect(mockedAxios.put).toHaveBeenCalledTimes(1);

--- a/src/components/editMeasure/editor/MeasureEditor.tsx
+++ b/src/components/editMeasure/editor/MeasureEditor.tsx
@@ -393,8 +393,7 @@ const MeasureEditor = () => {
               );
             }
             if (secondaryMessages.length > 0) {
-              primaryMessage =
-                "CQL updated successfully but the following issues were found";
+              primaryMessage += " but the following issues were found";
             }
             setSuccess({
               status: "success",

--- a/src/components/editMeasure/editor/StatusHandler.scss
+++ b/src/components/editMeasure/editor/StatusHandler.scss
@@ -9,7 +9,7 @@
       line-height: normal;
     }
     .secondary {
-      margin-bottom: 5px;
+      margin-bottom: 12px;
       ~ ul,
       ~ ol {
         margin-bottom: 0;

--- a/src/components/editMeasure/editor/StatusHandler.test.tsx
+++ b/src/components/editMeasure/editor/StatusHandler.test.tsx
@@ -19,11 +19,13 @@ describe("StatusHandler Component", () => {
     },
   ];
 
+  const success = {
+    status: "success",
+    primaryMessage: "CQL updated successfully",
+    secondaryMessages: ["Library statement can not be updated"],
+  };
+
   it("Should display success message, an errorMessage and outbound annotations", () => {
-    const success = {
-      status: "success",
-      message: "",
-    };
     const warningMessage =
       "You forgot to cover the edge case for fire helpers that aren't fire helpers";
     render(
@@ -35,12 +37,11 @@ describe("StatusHandler Component", () => {
         hasSubTitle={false}
       />
     );
-
     expect(screen.getByTestId("generic-success-text-header")).toHaveTextContent(
-      "Changes saved successfully but the following issues were found"
+      success.primaryMessage
     );
     expect(screen.getByTestId("library-warning")).toHaveTextContent(
-      warningMessage
+      success.secondaryMessages.join()
     );
     const errorsList = screen.getByTestId("generic-errors-text-list");
     expect(errorsList).toBeInTheDocument();
@@ -54,42 +55,7 @@ describe("StatusHandler Component", () => {
     );
   });
 
-  it("Should display a Success message along with Error Message but no Annotations", () => {
-    const success = {
-      status: "success",
-      message: "",
-    };
-    const errorMessage = "An error occurred, but CQL is saved successfully";
-    render(
-      <StatusHandler
-        success={success}
-        error={false}
-        errorMessage={errorMessage}
-        outboundAnnotations={[]}
-        hasSubTitle={false}
-      />
-    );
-
-    expect(screen.getByTestId("generic-success-text-header")).toHaveTextContent(
-      "Changes saved successfully but the following issues were found"
-    );
-    expect(screen.getByTestId("library-warning")).toHaveTextContent(
-      errorMessage
-    );
-    expect(
-      screen.queryByTestId("generic-errors-text-list")
-    ).not.toBeInTheDocument();
-    expect(
-      screen.queryByTestId("generic-warnings-text-list")
-    ).not.toBeInTheDocument();
-  });
-
   it("Should display a generic success message and a library warning if a library warning exists when no error or messages present, also displays a list of annotations", () => {
-    const success = {
-      status: "success",
-      message:
-        "CQL updated successfully! Library Statement or Using Statement were incorrect. MADiE has overwritten them to ensure proper CQL.",
-    };
     render(
       <StatusHandler
         success={success}
@@ -101,10 +67,10 @@ describe("StatusHandler Component", () => {
     );
 
     expect(getByTestId("generic-success-text-header")).toHaveTextContent(
-      "Changes saved successfully but the following issues were found"
+      success.primaryMessage
     );
     expect(screen.getByTestId("library-warning")).toHaveTextContent(
-      success.message
+      success.secondaryMessages.join()
     );
     const errorsList = screen.getByTestId("generic-errors-text-list");
     expect(errorsList).toBeInTheDocument();
@@ -119,11 +85,6 @@ describe("StatusHandler Component", () => {
   });
 
   it("Should display a generic success message and a using warning if a library warning exists when no error or messages present, also displays a list of annotations", async () => {
-    const success = {
-      status: "success",
-      message:
-        "CQL updated successfully but was missing a Using statement. Please add in a valid model and version.",
-    };
     render(
       <StatusHandler
         success={success}
@@ -135,11 +96,11 @@ describe("StatusHandler Component", () => {
     );
 
     expect(getByTestId("generic-success-text-header")).toHaveTextContent(
-      "Changes saved successfully but the following issues were found"
+      success.primaryMessage
     );
     await waitFor(() => {
       expect(screen.getByTestId("library-warning")).toHaveTextContent(
-        success.message
+        success.secondaryMessages.join()
       );
     });
     const errorsList = screen.getByTestId("generic-errors-text-list");
@@ -154,42 +115,7 @@ describe("StatusHandler Component", () => {
     );
   });
 
-  it("Should display a success message, with a list of annotations", () => {
-    const success = {
-      status: "success",
-      message: "",
-    };
-    render(
-      <StatusHandler
-        success={success}
-        error={false}
-        errorMessage={null}
-        outboundAnnotations={annotationsObject}
-        hasSubTitle={false}
-      />
-    );
-
-    expect(getByTestId("generic-success-text-header")).toHaveTextContent(
-      "Changes saved successfully but the following issues were found"
-    );
-    expect(screen.queryByTestId("library-warning")).not.toBeInTheDocument();
-    const errorsList = screen.getByTestId("generic-errors-text-list");
-    expect(errorsList).toBeInTheDocument();
-    expect(errorsList).toHaveTextContent(
-      transformAnnotation(annotationsObject[0])
-    );
-    const warningsList = screen.getByTestId("generic-warnings-text-list");
-    expect(warningsList).toBeInTheDocument();
-    expect(warningsList).toHaveTextContent(
-      transformAnnotation(annotationsObject[1])
-    );
-  });
-
   it("Should display a generic success message when no error or messages present", () => {
-    const success = {
-      status: "success",
-      message: "stuff saved successfully",
-    };
     render(
       <StatusHandler
         success={success}
@@ -201,7 +127,7 @@ describe("StatusHandler Component", () => {
     );
 
     expect(getByTestId("generic-success-text-header")).toHaveTextContent(
-      success.message
+      success.primaryMessage
     );
     expect(
       screen.queryByTestId("generic-errors-text-list")

--- a/src/components/editMeasure/editor/StatusHandler.tsx
+++ b/src/components/editMeasure/editor/StatusHandler.tsx
@@ -5,7 +5,7 @@ import * as _ from "lodash";
 const generateMadieAlertWithContent = (
   type,
   header,
-  secondaryMessage,
+  secondaryMessages,
   outboundAnnotations
 ) => {
   const errorAnnotation = _.filter(outboundAnnotations, { type: "error" });
@@ -30,9 +30,13 @@ const generateMadieAlertWithContent = (
           >
             {header}
           </h3>
-          {secondaryMessage && (
+          {secondaryMessages?.length > 0 && (
             <p className="secondary" data-testid="library-warning">
-              {secondaryMessage}
+              <ul style={{ listStyle: "inside" }}>
+                {secondaryMessages.map((message) => (
+                  <li>{message}</li>
+                ))}
+              </ul>
             </p>
           )}
           {errors?.length > 0 && (
@@ -79,52 +83,20 @@ const StatusHandler = ({
     success alone
   */
   if (success?.status === "success") {
-    if (errorMessage) {
-      if (outboundAnnotations?.length > 0) {
-        // Succesfully saved with errorMessage and outBoundAnnotations
-        return generateMadieAlertWithContent(
-          success.status,
-          "Changes saved successfully but the following issues were found",
-          errorMessage,
-          outboundAnnotations
-        );
-      } else {
-        // Succesfully saved with errorMessage
-        return generateMadieAlertWithContent(
-          success.status,
-          "Changes saved successfully but the following issues were found",
-          errorMessage,
-          null
-        );
-      }
-    } else if (outboundAnnotations && outboundAnnotations.length > 0) {
-      // Succesfully saved with outboundAnnotations and a warning messages
-      if (
-        success.message ===
-          "CQL updated successfully but was missing a Using statement. Please add in a valid model and version." ||
-        success.message ===
-          "CQL updated successfully! Library Statement or Using Statement were incorrect. MADiE has overwritten them to ensure proper CQL."
-      ) {
-        return generateMadieAlertWithContent(
-          success.status,
-          "Changes saved successfully but the following issues were found",
-          success.message,
-          outboundAnnotations
-        );
-      } else {
-        return generateMadieAlertWithContent(
-          success.status,
-          "Changes saved successfully but the following issues were found",
-          null,
-          outboundAnnotations
-        );
-      }
-    } else {
-      // Successfully saved with no errorMessage or outBoundAnnotations
+    if (outboundAnnotations?.length > 0) {
+      // Successfully saved with errorMessage and outBoundAnnotations
       return generateMadieAlertWithContent(
         success.status,
-        success.message,
-        null,
+        success.primaryMessage,
+        success.secondaryMessages,
+        outboundAnnotations
+      );
+    } else {
+      // Successfully saved with errorMessage
+      return generateMadieAlertWithContent(
+        success.status,
+        success.primaryMessage,
+        success.secondaryMessages,
         null
       );
     }


### PR DESCRIPTION
MAT-7246 QDM - Remove Value Set Versions from CQL and notify user, refactored status handler

## MADiE PR

Jira Ticket: [MAT-7246](https://jira.cms.gov/browse/MAT-7246)
(Optional) Related Tickets:
related PR: https://github.com/MeasureAuthoringTool/madie-cql-library/pull/146

### Summary
- Value set with version will be reverted
- Generic message that was being shown earlier for library statement and using statement is split into separate messages
 
### All Submissions
* [x] This PR has the JIRA linked.
* [x] Required tests are included.
* [x] No extemporaneous files are included (i.e Complied files or testing results).
* [x] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).
* [ ] All CDN/Web dependencies are hosted internally (i.e MADiE-Root Repo).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.


https://github.com/MeasureAuthoringTool/madie-measure/assets/23436747/b4ab91da-48c8-4e2c-a179-0be26641c618

