### PR TITLE
[MAT-7316] Swap in model agnostic feature flag for displaying CQL Builder Tabs

### DIFF
--- a/src/__mocks__/@madie/madie-editor.tsx
+++ b/src/__mocks__/@madie/madie-editor.tsx
@@ -24,7 +24,12 @@ export function MadieEditor({ onChange, value, inboundAnnotations }) {
   );
 }
 
-export function MadieTerminologyEditor({ onChange, value, handleCodeDelete }) {
+export function MadieTerminologyEditor({
+  onChange,
+  value,
+  inboundAnnotations,
+  handleCodeDelete,
+}) {
   const code = {
     codeSystem: "RXNORM",
     codeSystemOid: "2.16.840.1.113883.6.88",
@@ -44,6 +49,11 @@ export function MadieTerminologyEditor({ onChange, value, handleCodeDelete }) {
           onChange(e.target.value);
         }}
       />
+      {inboundAnnotations && inboundAnnotations.length > 0 ? (
+        <span>{inboundAnnotations.length} issues found with CQL</span>
+      ) : (
+        <span>CQL is valid</span>
+      )}
       <button data-testid="delete-code" onClick={() => handleCodeDelete(code)}>
         Remove code
       </button>

--- a/src/components/editMeasure/editor/MeasureEditor.test.tsx
+++ b/src/components/editMeasure/editor/MeasureEditor.test.tsx
@@ -48,7 +48,7 @@ jest.mock("@madie/madie-util", () => ({
     return true;
   }),
   useFeatureFlags: jest.fn().mockReturnValue({
-    qdmCodeSearch: true,
+    CQLBuilderTabs: true,
   }),
   measureStore: {
     updateMeasure: jest.fn((measure) => measure),

--- a/src/components/editMeasure/editor/MeasureEditor.tsx
+++ b/src/components/editMeasure/editor/MeasureEditor.tsx
@@ -581,7 +581,7 @@ const MeasureEditor = () => {
             </SuccessText>
           )}
           {!processing &&
-            (featureFlags?.qdmCodeSearch && isQDM ? (
+            (featureFlags?.CQLBuilderTabs ? (
               <MadieTerminologyEditor
                 handleApplyCode={handleApplyCode}
                 handleApplyValueSet={handleUpdateVs}

--- a/src/types/madie-madie-util.d.ts
+++ b/src/types/madie-madie-util.d.ts
@@ -17,6 +17,7 @@ declare module "@madie/madie-util" {
     MeasureListCheckboxes: boolean;
     associateMeasures: boolean;
     qiCoreStu4Updates: boolean;
+    CQLBuilderTabs: boolean;
   }
 
   export interface ServiceConfig {


### PR DESCRIPTION
## MADiE PR

Jira Ticket: [MAT-7316](https://jira.cms.gov/browse/MAT-7316)
(Optional) Related Tickets:

### Summary

Replace `qdmCodeSearch` flag with model agnostic and higher order `CQLBuilderTabs` feature flag to control when the CQL Builder Tabs are displayed.

### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included.
* [ ] No extemporaneous files are included (i.e Complied files or testing results).
* [ ] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).
* [ ] All CDN/Web dependencies are hosted internally (i.e MADiE-Root Repo).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
