### PR TITLE
[MAT-7316] Simplify feature flags controlling editor tabs

### DIFF
--- a/src/components/editMeasure/editor/MeasureEditor.test.tsx
+++ b/src/components/editMeasure/editor/MeasureEditor.test.tsx
@@ -48,7 +48,10 @@ jest.mock("@madie/madie-util", () => ({
     return true;
   }),
   useFeatureFlags: jest.fn().mockReturnValue({
-    CQLBuilderTabs: true,
+    QDMValueSetSearch: true,
+    qdmCodeSearch: true,
+    CQLBuilderDefinitions: true,
+    CQLBuilderIncludes: true,
   }),
   measureStore: {
     updateMeasure: jest.fn((measure) => measure),

--- a/src/components/editMeasure/editor/MeasureEditor.tsx
+++ b/src/components/editMeasure/editor/MeasureEditor.tsx
@@ -112,6 +112,11 @@ const MeasureEditor = () => {
   const [processing, setProcessing] = useState<boolean>(true);
   const featureFlags = useFeatureFlags();
   const isQDM = measure?.model?.includes("QDM");
+  const showCqlBuilderTabs =
+    featureFlags?.QDMValueSetSearch ||
+    featureFlags?.qdmCodeSearch ||
+    featureFlags?.CQLBuilderDefinitions ||
+    featureFlags?.CQLBuilderIncludes;
 
   useEffect(() => {
     const subscription = measureStore.subscribe((measure: Measure) => {
@@ -581,7 +586,7 @@ const MeasureEditor = () => {
             </SuccessText>
           )}
           {!processing &&
-            (featureFlags?.CQLBuilderTabs ? (
+            (showCqlBuilderTabs ? (
               <MadieTerminologyEditor
                 handleApplyCode={handleApplyCode}
                 handleApplyValueSet={handleUpdateVs}

--- a/src/types/madie-madie-util.d.ts
+++ b/src/types/madie-madie-util.d.ts
@@ -15,7 +15,10 @@ declare module "@madie/madie-util" {
     MeasureListCheckboxes: boolean;
     associateMeasures: boolean;
     qiCoreStu4Updates: boolean;
-    CQLBuilderTabs: boolean;
+    QDMValueSetSearch: boolean;
+    qdmCodeSearch: boolean;
+    CQLBuilderDefinitions: boolean;
+    CQLBuilderIncludes: boolean;
   }
 
   export interface ServiceConfig {


### PR DESCRIPTION
## MADiE PR

Jira Ticket: [MAT-7316](https://jira.cms.gov/browse/MAT-7316)
(Optional) Related Tickets:

### Summary

Replace "CQLBuilderTabs" flag with a computed boolean based on the individual CQL Builder flags (VS, Code, Definitions, and Include atm).

The "CQLBuilderTabs" Flag was, in essence, a clever way to handle enabling/disabling all of the Builder tabs. We should avoid being clever as it adds unnecessary complexity. The result of this clever configuration caused immense confusion due to requiring multiple flags to control individual features.

### All Submissions
* [x] This PR has the JIRA linked.
* [x] Required tests are included.
* [ ] No extemporaneous files are included (i.e Complied files or testing results).
* [ ] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).
* [ ] All CDN/Web dependencies are hosted internally (i.e MADiE-Root Repo).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
