### PR TITLE
MAT-7852: set activeOnly argument to false when expansion type is Lat…

### DIFF
--- a/src/components/editMeasure/testCases/api/TerminologyServiceApi.test.ts
+++ b/src/components/editMeasure/testCases/api/TerminologyServiceApi.test.ts
@@ -82,7 +82,7 @@ describe("TerminologyServiceApi Tests", () => {
       });
   });
 
-  it("Should call Terminology Service URL to fetch value set expansions when manifest Expansion feature flag is true", () => {
+  it("Should call Terminology Service URL to fetch value set expansions when manifest Expansion feature flag is true and activeOnly is set to 'true' when manifestExpansion is truthy (expansion type is Manifest)", () => {
     axios.put = jest
       .fn()
       .mockResolvedValue({ data: cqm_measure_basic_valueset });
@@ -99,6 +99,32 @@ describe("TerminologyServiceApi Tests", () => {
           fullUrl: "https://cts.nlm.nih.gov/fhir/Library/mu2-update-2015-05-01",
           id: "mu2-update-2015-05-01",
         },
+        activeOnly: "true",
+        profile: "",
+        valueSetParams: [
+          { oid: "2.16.840.1.113883.3.666.5.307" },
+          { oid: "2.16.840.1.113883.3.464.1003.103.12.1001" },
+        ],
+      },
+      { headers: { Authorization: "Bearer undefined" }, signal: true }
+    );
+  });
+
+  it("Should call Terminology Service URL to fetch value set expansions when manifest Expansion feature flag is true and activeOnly is set to 'false' when manifestExpansion is falsy (expansion type is Latest)", () => {
+    axios.put = jest
+      .fn()
+      .mockResolvedValue({ data: cqm_measure_basic_valueset });
+    const result = terminologyService.getQdmValueSetsExpansion(
+      cqm_measure_basic,
+      null,
+      true
+    );
+    expect(axios.put).toBeCalledWith(
+      "test.url/terminology/value-sets/expansion/qdm",
+      {
+        includeDraft: "yes",
+        manifestExpansion: null,
+        activeOnly: "false",
         profile: "",
         valueSetParams: [
           { oid: "2.16.840.1.113883.3.666.5.307" },
@@ -126,6 +152,7 @@ describe("TerminologyServiceApi Tests", () => {
                 "https://cts.nlm.nih.gov/fhir/Library/mu2-update-2015-05-01",
               id: "mu2-update-2015-05-01",
             },
+            activeOnly: "true",
             profile: "",
             valueSetParams: [
               { oid: "2.16.840.1.113883.3.666.5.307" },

--- a/src/components/editMeasure/testCases/api/useTerminologyServiceApi.ts
+++ b/src/components/editMeasure/testCases/api/useTerminologyServiceApi.ts
@@ -17,6 +17,7 @@ type ValueSetSearchParams = {
 type ValueSetsSearchCriteria = {
   profile: string;
   includeDraft: "yes" | "no";
+  activeOnly: string;
   manifestExpansion: ManifestExpansion;
   valueSetParams: ValueSetSearchParams[];
 };
@@ -78,6 +79,7 @@ export class TerminologyServiceApi {
     }
     const searchCriteria: ValueSetsSearchCriteria = {
       includeDraft: "yes", // always yes for now
+      activeOnly: manifestExpansion ? "true" : "false",
       profile: "",
       manifestExpansion: manifestExpansion,
       valueSetParams: this.getValueSetsOIDsFromCqmMeasure(


### PR DESCRIPTION
…est (when manifestExpansion is null, expansion type is Latest. When manifestExpansion is not null, expansion type is Manifest)

## MADiE PR

Jira Ticket: [MAT-7852](https://jira.cms.gov/browse/MAT-7852)
(Optional) Related Tickets:

### Summary

### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included.
* [ ] No extemporaneous files are included (i.e Complied files or testing results).
* [ ] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).
* [ ] All CDN/Web dependencies are hosted internally (i.e MADiE-Root Repo).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
