### PR TITLE
MAT-8019: Replace QICore STU6 Test Case lenient validation warning with notice of validations being wholly disabled.

### DIFF
--- a/src/components/editMeasure/testCases/components/editTestCase/qiCore/EditTestCase.tsx
+++ b/src/components/editMeasure/testCases/components/editTestCase/qiCore/EditTestCase.tsx
@@ -659,8 +659,9 @@ const EditTestCase = (props: EditTestCaseProps) => {
   }
 
   function isHapiOutcomeIssueCodeInformational(outcome: HapiOperationOutcome) {
+    if (_.isNil(outcome?.outcomeResponse?.issue)) return true; // no issues, valid.
     return (
-      outcome?.outcomeResponse?.issue.filter(
+      outcome?.outcomeResponse?.issue?.filter(
         (issue) => /^information/.exec(issue.severity) === null
       ).length <= 0
     );
@@ -836,7 +837,7 @@ const EditTestCase = (props: EditTestCaseProps) => {
   }, [measure?.groups]);
   return (
     <>
-      {isQICore6 && (
+      {isQICore6 && !featureFlags?.stu6TestCaseValidation && (
         <div id="status-handler">
           <MadieAlert
             type="warning"
@@ -847,10 +848,13 @@ const EditTestCase = (props: EditTestCaseProps) => {
                 data-testid={"terminology-validation-warning"}
               >
                 <strong>Warning: </strong>
-                Terminology validations for QI-Core STU6 are set to lenient. Any
-                validations on codes, codesystem, or valuesets will be displayed
-                as warning messages. Please ensure your terminology is accurate
-                to prevent errors when strict validations are turned on.
+                Validations for QI-Core STU6 are Disabled. No validations will
+                be displayed. Validation of your Test Case JSON can be performed
+                using an alternative tool, such as the{" "}
+                <a href={"https://validator.fhir.org/"}>
+                  HL7 FHIR Validator
+                </a>{" "}
+                with the US-Core and QI-Core IGs selected.
               </div>
             }
             canClose={false}

--- a/src/types/madie-madie-util.d.ts
+++ b/src/types/madie-madie-util.d.ts
@@ -16,6 +16,7 @@ declare module "@madie/madie-util" {
     qiCoreElementsTab: boolean;
     qdmHideJson: boolean;
     TestCaseListButtons: boolean;
+    stu6TestCaseValidation: boolean;
   }
 
   export interface ServiceConfig {


### PR DESCRIPTION
Ignore HAPI responses with empty Issue arrays.

## MADiE PR

Jira Ticket: [MAT-8019](https://jira.cms.gov/browse/MAT-8019)
(Optional) Related Tickets:

### Summary

Updating the warning message that appears on QICore STU6 Test Cases individual Edit Test Case pages to reflect that _all_ HAPI validations are disabled.

### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included.
* [ ] No extemporaneous files are included (i.e Complied files or testing results).
* [ ] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).
* [ ] All CDN/Web dependencies are hosted internally (i.e MADiE-Root Repo).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
