### PR TITLE
MAT-7961: Trim the eCQM Abbreviated Title when used in file names.

### DIFF
--- a/src/components/measureLanding/measureList/MeasureList.tsx
+++ b/src/components/measureLanding/measureList/MeasureList.tsx
@@ -543,7 +543,7 @@ export default function MeasureList(props: {
     link.href = url;
     link.setAttribute(
       "download",
-      `${ecqmTitle}-v${version}-${getModelFamily(model)}.zip`
+      `${_.trim(ecqmTitle)}-v${version}-${getModelFamily(model)}.zip`
     );
     document.body.appendChild(link);
     link.click();

--- a/src/utils/exportUtil.ts
+++ b/src/utils/exportUtil.ts
@@ -18,7 +18,7 @@ export const downloadZipFile = (
   link.href = url;
   link.setAttribute(
     "download",
-    `${ecqmTitle}-v${version}-${getModelFamily(model)}.zip`
+    `${_.trim(ecqmTitle)}-v${version}-${getModelFamily(model)}.zip`
   );
   document.body.appendChild(link);
   link.click();


### PR DESCRIPTION
## MADiE PR

Jira Ticket: [MAT-7961](https://jira.cms.gov/browse/MAT-7961)
(Optional) Related Tickets:

### Summary

Trim excess leading and trailing whitespace from the eCQM Abbreviated title when it is used in a filename.

### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included.
* [ ] No extemporaneous files are included (i.e Complied files or testing results).
* [ ] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).
* [ ] All CDN/Web dependencies are hosted internally (i.e MADiE-Root Repo).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
