### PR TITLE
MAT-8255: Implement a reusable hook to listen for a resetAllForms cal…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9671,9 +9671,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "2.5.8",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.5.8.tgz",
-      "integrity": "sha512-o1vSNgrmYMQObbSSvF/1brBYEQPHhV1+gsmrusO7/GXtp1T9rCS8cXFqVxK/9crT1jA6Ccv+5MTSjBNqr7Sovw==",
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.5.7.tgz",
+      "integrity": "sha512-2q4bEI+coQM8f5ez7kt2xclg1XsecaV9ASJk/54vwlfRRNQfDqJz2pzQ8t0Ix/ToBpXlVjrRIx7pFC/o8itG2Q==",
       "dev": true
     },
     "node_modules/domutils": {
@@ -9741,10 +9741,11 @@
       "integrity": "sha512-u7000ZB/X0K78TaQqXZ5ktoR7J79B9US7IkE4zyvcILYwOGY2Tx9GRPYstn7HmuPcMxZ+BDGqIsyLpZQi9ufPw=="
     },
     "node_modules/elliptic": {
-      "version": "6.6.1",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
-      "integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.0.tgz",
+      "integrity": "sha512-dpwoQcLc/2WLQvJvLRHKZ+f9FgOdjnq11rurqwekGQygGPsYSK29OMMD2WalatiqQ+XGFDglTNixpPfI+lpaAA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "bn.js": "^4.11.9",
         "brorand": "^1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9671,9 +9671,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "2.5.7",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.5.7.tgz",
-      "integrity": "sha512-2q4bEI+coQM8f5ez7kt2xclg1XsecaV9ASJk/54vwlfRRNQfDqJz2pzQ8t0Ix/ToBpXlVjrRIx7pFC/o8itG2Q==",
+      "version": "2.5.8",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.5.8.tgz",
+      "integrity": "sha512-o1vSNgrmYMQObbSSvF/1brBYEQPHhV1+gsmrusO7/GXtp1T9rCS8cXFqVxK/9crT1jA6Ccv+5MTSjBNqr7Sovw==",
       "dev": true
     },
     "node_modules/domutils": {
@@ -9741,11 +9741,10 @@
       "integrity": "sha512-u7000ZB/X0K78TaQqXZ5ktoR7J79B9US7IkE4zyvcILYwOGY2Tx9GRPYstn7HmuPcMxZ+BDGqIsyLpZQi9ufPw=="
     },
     "node_modules/elliptic": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.0.tgz",
-      "integrity": "sha512-dpwoQcLc/2WLQvJvLRHKZ+f9FgOdjnq11rurqwekGQygGPsYSK29OMMD2WalatiqQ+XGFDglTNixpPfI+lpaAA==",
+      "version": "6.6.1",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
+      "integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "bn.js": "^4.11.9",
         "brorand": "^1.1.0",

--- a/src/components/common/useFormikResetOnEvent.test.tsx
+++ b/src/components/common/useFormikResetOnEvent.test.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import { renderHook } from "@testing-library/react-hooks";
+import useFormikResetOnEvent from "./useFormikResetOnEvent";
+
+describe("useFormikResetOnEvent", () => {
+  it("calls formik.resetForm when resetAllForms event is dispatched", () => {
+    const resetForm = jest.fn();
+    const formik = { resetForm };
+
+    renderHook(() => useFormikResetOnEvent(formik));
+    window.dispatchEvent(new Event("resetAllForms"));
+
+    expect(resetForm).toHaveBeenCalledTimes(1);
+  });
+
+  it("removes event listener on unmount", () => {
+    const resetForm = jest.fn();
+    const formik = { resetForm };
+
+    const { unmount } = renderHook(() => useFormikResetOnEvent(formik));
+
+    unmount();
+    window.dispatchEvent(new Event("resetAllForms"));
+    expect(resetForm).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/common/useFormikResetOnEvent.ts
+++ b/src/components/common/useFormikResetOnEvent.ts
@@ -1,0 +1,20 @@
+import { useEffect } from "react";
+
+// reusable component to hook into form locations.
+// We have a discard dialog in the measure-actions-center that needs to know about every other form in the app, and trigger the reset onContinue
+// We could have that onContinue logic emit an event, and this component should add the listener on each form that needs to blank.
+const useFormikResetOnEvent = (formik) => {
+  useEffect(() => {
+    const handleEvent = () => {
+      formik.resetForm();
+    };
+
+    window.addEventListener("resetAllForms", handleEvent);
+
+    return () => {
+      window.removeEventListener("resetAllForms", handleEvent);
+    };
+  }, [formik]);
+};
+
+export default useFormikResetOnEvent;

--- a/src/components/editMeasure/details/MeasureDefinitions/MeasureDefinitions.tsx
+++ b/src/components/editMeasure/details/MeasureDefinitions/MeasureDefinitions.tsx
@@ -14,6 +14,7 @@ import { Typography, IconButton } from "@mui/material";
 import AddIcon from "@mui/icons-material/Add";
 import { measureStore, checkUserCanEdit } from "@madie/madie-util";
 import { useFormik } from "formik";
+import useFormikResetOnEvent from "../../../common/useFormikResetOnEvent";
 import { MeasureDefinition } from "@madie/madie-models";
 import MeasureMetaDataRow from "../MeasureMetaDataRow";
 import { MeasureDefinitionValidator } from "./MeasureDefinitionValidator";
@@ -62,6 +63,7 @@ const MeasureDefinitions = (props: MeasureDefinitionsProps) => {
     validationSchema: MeasureDefinitionValidator,
     onSubmit: async (values) => await handleSubmit(values),
   });
+  useFormikResetOnEvent(formik);
 
   useEffect(() => {
     if (measure?.measureMetaData?.measureDefinitions) {

--- a/src/components/editMeasure/details/MeasureReferences/MeasureReferences.tsx
+++ b/src/components/editMeasure/details/MeasureReferences/MeasureReferences.tsx
@@ -15,6 +15,7 @@ import { Typography, MenuItem } from "@mui/material";
 import AddIcon from "@mui/icons-material/Add";
 import { measureStore, checkUserCanEdit } from "@madie/madie-util";
 import { useFormik } from "formik";
+import useFormikResetOnEvent from "../../../common/useFormikResetOnEvent";
 import MeasureMetaDataRow from "../MeasureMetaDataRow";
 import { MeasureReferencesValidator } from "./MeasureReferencesValidator";
 import { Measure, Reference } from "@madie/madie-models";
@@ -181,6 +182,7 @@ const MeasureReferences = (props: MeasureReferencesProps) => {
     validationSchema: MeasureReferencesValidator,
     onSubmit: async (values: Reference) => await handleSubmit(values),
   });
+  useFormikResetOnEvent(formik);
 
   function formikErrorHandler(name: string, isError: boolean) {
     if (formik.touched[name] && formik.errors[name]) {

--- a/src/components/editMeasure/details/TransmissionFormat/TransmissionFormat.tsx
+++ b/src/components/editMeasure/details/TransmissionFormat/TransmissionFormat.tsx
@@ -14,6 +14,7 @@ import {
 } from "@madie/madie-util";
 import { useFormik } from "formik";
 import * as Yup from "yup";
+import useFormikResetOnEvent from "../../../common/useFormikResetOnEvent";
 
 interface TransmissionFormatProps {
   setErrorMessage: Function;
@@ -85,6 +86,8 @@ const TransmissionFormat = (props: TransmissionFormatProps) => {
     enableReinitialize: true,
     onSubmit: async (values) => await handleSubmit(values),
   });
+  useFormikResetOnEvent(formik);
+
   function formikErrorHandler(name: string, isError: boolean) {
     if (formik.touched[name] && formik.errors[name]) {
       return `${formik.errors[name]}`;

--- a/src/components/editMeasure/details/measureInformation/MeasureInformation.tsx
+++ b/src/components/editMeasure/details/measureInformation/MeasureInformation.tsx
@@ -20,6 +20,7 @@ import {
 } from "@mui/material";
 import { useFormik } from "formik";
 import { MeasureSchemaValidator } from "../../../../validations/MeasureSchemaValidator";
+import useFormikResetOnEvent from "../../../common/useFormikResetOnEvent";
 import {
   measureStore,
   routeHandlerStore,
@@ -215,6 +216,7 @@ export default function MeasureInformation(props: MeasureInformationProps) {
     onSubmit: async (values: measureInformationForm) =>
       await handleSubmit(values),
   });
+  useFormikResetOnEvent(formik);
   const { resetForm } = formik;
   // tell our routehandler no go
   const { updateRouteHandlerState } = routeHandlerStore;

--- a/src/components/editMeasure/details/measureMetadata/MeasureMetadata.tsx
+++ b/src/components/editMeasure/details/measureMetadata/MeasureMetadata.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { useFormik } from "formik";
+import useFormikResetOnEvent from "../../../common/useFormikResetOnEvent";
 import { Typography } from "@mui/material";
 import useMeasureServiceApi from "../../../../api/useMeasureServiceApi";
 import getInitialValues, { setMeasureMetadata } from "./MeasureMetadataHelper";
@@ -67,6 +68,7 @@ export default function MeasureMetadata(props: MeasureMetadataProps) {
       submitForm(values.genericField.trim());
     },
   });
+  useFormikResetOnEvent(formik);
 
   const goBackToNav = (e) => {
     if (e.shiftKey && e.keyCode == 9) {

--- a/src/components/editMeasure/details/modelAndMeasurementPeriod/ModelAndMeasurementPeriod.tsx
+++ b/src/components/editMeasure/details/modelAndMeasurementPeriod/ModelAndMeasurementPeriod.tsx
@@ -12,6 +12,7 @@ import {
 
 import { Typography } from "@mui/material";
 import { useFormik } from "formik";
+import useFormikResetOnEvent from "../../../common/useFormikResetOnEvent";
 import { MeasurementPeriodValidator } from "../../../../validations/MeasurementPeriodValidator";
 import {
   measureStore,
@@ -83,6 +84,7 @@ const ModelAndMeasurementPeriod = (props: ModelAndMeasurementPeriodProps) => {
     onSubmit: async (values: modelAndMeasurementPeriod) =>
       await handleSubmit(values),
   });
+  useFormikResetOnEvent(formik);
   const { resetForm } = formik;
   // update our routehandler discard dialog
   const { updateRouteHandlerState } = routeHandlerStore;

--- a/src/components/editMeasure/details/stewardAndDevelopers/StewardAndDevelopers.tsx
+++ b/src/components/editMeasure/details/stewardAndDevelopers/StewardAndDevelopers.tsx
@@ -15,6 +15,7 @@ import {
   checkUserCanEdit,
 } from "@madie/madie-util";
 import { useFormik } from "formik";
+import useFormikResetOnEvent from "../../../common/useFormikResetOnEvent";
 import * as Yup from "yup";
 import { Checkbox, Typography } from "@mui/material";
 import { Organization } from "@madie/madie-models";
@@ -73,6 +74,7 @@ export default function StewardAndDevelopers(props: StewardAndDevelopersProps) {
       submitForm(values);
     },
   });
+  useFormikResetOnEvent(formik);
   const { resetForm } = formik;
 
   // Updates the measure in DB, and also the measureStore

--- a/src/components/editMeasure/editor/MeasureEditor.test.tsx
+++ b/src/components/editMeasure/editor/MeasureEditor.test.tsx
@@ -544,6 +544,21 @@ describe("MeasureEditor component", () => {
     });
   });
 
+  it("reset editor on emitted event", async () => {
+    const { getByTestId } = renderEditor(measure);
+    const editorContainer = getByTestId("measure-editor") as HTMLInputElement;
+    expect(measure.cql).toEqual(editorContainer.value);
+    fireEvent.change(getByTestId("measure-editor"), {
+      target: {
+        value: "library testCql version '2.0.000'",
+      },
+    });
+    window.dispatchEvent(new Event("resetAllForms"));
+    await waitFor(() => {
+      expect(measure.cql).toEqual(editorContainer.value);
+    });
+  });
+
   it("it closes the dialog without changing the cql", async () => {
     const { getByTestId, queryByText } = renderEditor(measure);
     const editorContainer = getByTestId("measure-editor") as HTMLInputElement;

--- a/src/components/editMeasure/editor/MeasureEditor.tsx
+++ b/src/components/editMeasure/editor/MeasureEditor.tsx
@@ -760,7 +760,13 @@ const MeasureEditor = () => {
     setEditorVal(measure?.cql || "");
     setIsCQLUnchanged(true);
   };
-
+  // force a reset on this similair to formik objects.
+  useEffect(() => {
+    window.addEventListener("resetAllForms", resetCql);
+    return () => {
+      window.removeEventListener("resetAllForms", resetCql);
+    };
+  }, [resetCql]); // need access to resetCQl or it will not track what cql is and will set to ""
   const handleApplyDefinition = (defValues: Definition) => {
     handleMadieEditorValue(applyDefinition(defValues, editorVal));
     setToastType("success");

--- a/src/components/editMeasure/populationCriteria/QDMReporting/QDMReporting.tsx
+++ b/src/components/editMeasure/populationCriteria/QDMReporting/QDMReporting.tsx
@@ -20,6 +20,7 @@ import "./QDMReporting.scss";
 import { MenuItem as MuiMenuItem } from "@mui/material";
 import { QDMReportingValidator } from "./QDMReportingValidator";
 import _ from "lodash";
+import useFormikResetOnEvent from "../../../common/useFormikResetOnEvent";
 const Grid = tw.div`grid grid-cols-2 gap-4   overflow-hidden w-full`;
 const improvementNotationOptions = [
   {
@@ -90,8 +91,8 @@ const QDMReporting = () => {
     validationSchema: QDMReportingValidator,
     onSubmit: async (values: ReportingForm) => await handleSubmit(values),
   });
+  useFormikResetOnEvent(formik);
   const { resetForm } = formik;
-
   useEffect(() => {
     updateRouteHandlerState({
       canTravel: !formik.dirty,

--- a/src/components/editMeasure/populationCriteria/baseConfiguration/BaseConfiguration.tsx
+++ b/src/components/editMeasure/populationCriteria/baseConfiguration/BaseConfiguration.tsx
@@ -23,6 +23,7 @@ import {
 } from "@madie/madie-design-system/dist/react";
 import "./BaseConfiguration.scss";
 import MeasureGroupsWarningDialog from "../groups/MeasureGroupWarningDialog";
+import useFormikResetOnEvent from "../../../common/useFormikResetOnEvent";
 
 interface BaseConfigurationForm {
   scoring: string;
@@ -74,8 +75,8 @@ const BaseConfiguration = () => {
     validationSchema: QDMMeasureSchemaValidator,
     onSubmit: async (values: BaseConfigurationForm) => await handleSubmit(),
   });
+  useFormikResetOnEvent(formik);
   const { resetForm } = formik;
-
   useEffect(() => {
     updateRouteHandlerState({
       canTravel: !formik.dirty,

--- a/src/components/editMeasure/populationCriteria/groups/QDM/QDMMeasureGroups.tsx
+++ b/src/components/editMeasure/populationCriteria/groups/QDM/QDMMeasureGroups.tsx
@@ -26,6 +26,7 @@ import {
   TextArea,
 } from "@madie/madie-design-system/dist/react";
 import { useFormik, FormikProvider, FieldArray, Field, getIn } from "formik";
+import useFormikResetOnEvent from "../../../../common/useFormikResetOnEvent";
 import useMeasureServiceApi from "../../../../../api/useMeasureServiceApi";
 import { v4 as uuidv4 } from "uuid";
 import {
@@ -349,6 +350,7 @@ const MeasureGroups = (props: MeasureGroupProps) => {
       }
     },
   });
+  useFormikResetOnEvent(formik);
   const { resetForm, validateForm } = formik;
   useEffect(() => {
     if (measure?.groups && measure?.groups[measureGroupNumber]) {

--- a/src/components/editMeasure/populationCriteria/groups/QICore/QICoreMeasureGroups.tsx
+++ b/src/components/editMeasure/populationCriteria/groups/QICore/QICoreMeasureGroups.tsx
@@ -32,6 +32,7 @@ import {
   TextArea,
 } from "@madie/madie-design-system/dist/react";
 import { useFormik, FormikProvider, FieldArray, Field, getIn } from "formik";
+import useFormikResetOnEvent from "../../../../common/useFormikResetOnEvent";
 import useMeasureServiceApi from "../../../../../api/useMeasureServiceApi";
 import { v4 as uuidv4 } from "uuid";
 import {
@@ -404,7 +405,7 @@ const MeasureGroups = (props: MeasureGroupProps) => {
       }
     },
   });
-
+  useFormikResetOnEvent(formik);
   const { resetForm, validateForm } = formik;
 
   useEffect(() => {

--- a/src/components/editMeasure/populationCriteria/riskAdjustment/qdm/RiskAdjustment.tsx
+++ b/src/components/editMeasure/populationCriteria/riskAdjustment/qdm/RiskAdjustment.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import "twin.macro";
 import "styled-components/macro";
 import { useFormik } from "formik";
+import useFormikResetOnEvent from "../../../../common/useFormikResetOnEvent";
 import useMeasureServiceApi from "../../../../../api/useMeasureServiceApi";
 import {
   checkUserCanEdit,
@@ -64,6 +65,7 @@ const RiskAdjustment = () => {
     validateOnChange: true,
     onSubmit: (values) => handleSubmit(values),
   });
+  useFormikResetOnEvent(formik);
   const { resetForm } = formik;
 
   const handleSubmit = (values) => {

--- a/src/components/editMeasure/populationCriteria/riskAdjustment/qiCore/RiskAdjustment.tsx
+++ b/src/components/editMeasure/populationCriteria/riskAdjustment/qiCore/RiskAdjustment.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import "twin.macro";
 import "styled-components/macro";
 import { useFormik } from "formik";
+import useFormikResetOnEvent from "../../../../common/useFormikResetOnEvent";
 import useMeasureServiceApi from "../../../../../api/useMeasureServiceApi";
 import {
   checkUserCanEdit,
@@ -89,6 +90,7 @@ const RiskAdjustment = () => {
     validateOnChange: true,
     onSubmit: (values) => handleSubmit(values),
   });
+  useFormikResetOnEvent(formik);
   const { resetForm } = formik;
 
   const handleSubmit = (values) => {

--- a/src/components/editMeasure/populationCriteria/supplementalData/qdm/SupplementalData.tsx
+++ b/src/components/editMeasure/populationCriteria/supplementalData/qdm/SupplementalData.tsx
@@ -14,6 +14,7 @@ import {
   checkUserCanEdit,
 } from "@madie/madie-util";
 import { useFormik } from "formik";
+import useFormikResetOnEvent from "../../../../common/useFormikResetOnEvent";
 import "../../../details/MeasureDetails.scss";
 import { CqlAntlr } from "@madie/cql-antlr-parser/dist/src";
 import { Measure } from "@madie/madie-models";
@@ -65,6 +66,7 @@ const SupplementalData = () => {
     validateOnChange: true,
     onSubmit: (values) => handleSubmit(values),
   });
+  useFormikResetOnEvent(formik);
   const { resetForm } = formik;
 
   const handleSubmit = (values) => {

--- a/src/components/editMeasure/populationCriteria/supplementalData/qiCore/SupplementalData.tsx
+++ b/src/components/editMeasure/populationCriteria/supplementalData/qiCore/SupplementalData.tsx
@@ -14,6 +14,7 @@ import {
   checkUserCanEdit,
 } from "@madie/madie-util";
 import { useFormik } from "formik";
+import useFormikResetOnEvent from "../../../../common/useFormikResetOnEvent";
 import "../../../details/MeasureDetails.scss";
 import { CqlAntlr } from "@madie/cql-antlr-parser/dist/src";
 import {
@@ -90,6 +91,7 @@ const SupplementalData = () => {
     validateOnChange: true,
     onSubmit: (values) => handleSubmit(values),
   });
+  useFormikResetOnEvent(formik);
   const { resetForm } = formik;
 
   const handleSubmit = (values) => {

--- a/src/components/editMeasure/testCases/components/editTestCase/qdm/EditTestCase.tsx
+++ b/src/components/editMeasure/testCases/components/editTestCase/qdm/EditTestCase.tsx
@@ -20,6 +20,7 @@ import EditTestCaseBreadCrumbs from "../EditTestCaseBreadCrumbs";
 import { useNavigate, useParams } from "react-router-dom";
 import useTestCaseServiceApi from "../../../api/useTestCaseServiceApi";
 import { useFormik, FormikProvider } from "formik";
+import useFormikResetOnEvent from "../../../../../common/useFormikResetOnEvent";
 import { QDMPatientSchemaValidator } from "./QDMPatientSchemaValidator";
 
 import "allotment/dist/style.css";
@@ -123,6 +124,7 @@ const EditTestCase = () => {
     validationSchema: QDMPatientSchemaValidator,
     onSubmit: async (values: any) => await handleSubmit(values),
   });
+  useFormikResetOnEvent(formik);
   const { resetForm } = formik;
 
   // Fetches test case based on ID, identifies measure.group converts it to testcase.groupPopulation

--- a/src/components/editMeasure/testCases/components/editTestCase/qdm/LeftPanel/ElementsTab/Elements/DataElementsCard/attributes/AttributeSection.tsx
+++ b/src/components/editMeasure/testCases/components/editTestCase/qdm/LeftPanel/ElementsTab/Elements/DataElementsCard/attributes/AttributeSection.tsx
@@ -11,6 +11,7 @@ import DisplayAttributeInputs from "./DisplayAttributeInputs";
 import AttributeChipList from "../AttributeChipList";
 import { MadieDiscardDialog } from "@madie/madie-design-system/dist/react";
 import { routeHandlerStore } from "@madie/madie-util";
+import useFormikResetOnEvent from "../../../../../../../../../../common/useFormikResetOnEvent";
 
 export interface Chip {
   title?: String;
@@ -48,6 +49,7 @@ const AttributeSection = ({
       onAddClicked(values.attribute, values.type, values.attributeValue);
     },
   });
+  useFormikResetOnEvent(formik);
   const { resetForm } = formik;
 
   const { updateRouteHandlerState } = routeHandlerStore;

--- a/src/components/editMeasure/testCases/components/editTestCase/qiCore/EditTestCase.tsx
+++ b/src/components/editMeasure/testCases/components/editTestCase/qiCore/EditTestCase.tsx
@@ -82,6 +82,7 @@ import { CqlDefinitionCallstack } from "../groupCoverage/QiCoreGroupCoverage";
 import useFhirCqlParsingService from "../../../api/cqlElmTranslationService/useFhirCqlParsingService";
 import checkSpecialCharacters from "../../../util/checkSpecialCharacters";
 import EditorSearch from "./LeftPanel/EditorSearch";
+import useFormikResetOnEvent from "../../../../../common/useFormikResetOnEvent";
 
 const TestCaseForm = tw.form`m-3`;
 const ValidationErrorsButton = tw.button`
@@ -300,6 +301,7 @@ const EditTestCase = (props: EditTestCaseProps) => {
     // enableReinitialize: true,
     onSubmit: async (values: TestCase) => await handleSubmit(values),
   });
+  useFormikResetOnEvent(formik);
   const { resetForm } = formik;
 
   //stu6 validation logic required
@@ -312,7 +314,7 @@ const EditTestCase = (props: EditTestCaseProps) => {
     validationSchema,
     onSubmit: () => {},
   });
-
+  useFormikResetOnEvent(formikStu6Context);
   //needs to be added to feature flag config once the feature flags are moved to Util
   const testCaseAlertToast = false;
 

--- a/src/components/editMeasure/testCases/components/editTestCase/qiCore/LeftPanel/ElementsTab/builder/element/ElementEditor.tsx
+++ b/src/components/editMeasure/testCases/components/editTestCase/qiCore/LeftPanel/ElementsTab/builder/element/ElementEditor.tsx
@@ -27,6 +27,7 @@ import {
 } from "../../../../../../../util/QiCorePatientProvider";
 import { useFormikContext } from "formik";
 import { Button } from "@madie/madie-design-system/dist/react";
+import useFormikResetOnEvent from "../../../../../../../../../common/useFormikResetOnEvent";
 
 interface ElementEditorProps {
   resource?: any;
@@ -207,7 +208,7 @@ const ElementEditor = ({
     }
   }, [selectedResource, displayedElementsTree]);
   const formik = useFormikContext();
-
+  useFormikResetOnEvent(formik);
   // on individual apply
   const handleIndividualElementApplyButtonClick = (e) => {
     // this is wrapped in a form and we need to prevent submit on click with e.prevent

--- a/src/components/editMeasure/testCases/components/testCaseConfiguration/expansion/Expansion.tsx
+++ b/src/components/editMeasure/testCases/components/testCaseConfiguration/expansion/Expansion.tsx
@@ -19,6 +19,7 @@ import { MenuItem, Typography } from "@mui/material";
 import * as Yup from "yup";
 import { useQdmExecutionContext } from "../../routes/qdm/QdmExecutionContext";
 import useTerminologyServiceApi from "../../../api/useTerminologyServiceApi";
+import useFormikResetOnEvent from "../../../../../common/useFormikResetOnEvent";
 
 const Expansion = () => {
   const { setExecutionContextReady } = useQdmExecutionContext();
@@ -78,6 +79,7 @@ const Expansion = () => {
     enableReinitialize: true,
     onSubmit: async (values) => await handleSubmit(values),
   });
+  useFormikResetOnEvent(formik);
   const { resetForm } = formik;
 
   const handleSubmit = async (values) => {

--- a/src/components/editMeasure/testCases/components/testCaseConfiguration/sde/SDEPage.tsx
+++ b/src/components/editMeasure/testCases/components/testCaseConfiguration/sde/SDEPage.tsx
@@ -16,6 +16,7 @@ import "../testCaseConfiguration.scss";
 import useMeasureServiceApi from "../../../api/useMeasureServiceApi";
 import { Typography } from "@mui/material";
 import { useQdmExecutionContext } from "../../routes/qdm/QdmExecutionContext";
+import useFormikResetOnEvent from "../../../../../common/useFormikResetOnEvent";
 
 const SDEPage = () => {
   const { setExecutionContextReady } = useQdmExecutionContext();
@@ -48,6 +49,7 @@ const SDEPage = () => {
     enableReinitialize: true,
     onSubmit: async () => await handleSubmit(),
   });
+  useFormikResetOnEvent(formik);
   const { resetForm } = formik;
 
   useEffect(() => {


### PR DESCRIPTION
 Implement a reusable hook to listen for a resetAllForms event call
 
## MADiE PR

Jira Ticket: [MAT-8255](https://jira.cms.gov/browse/MAT-8255)
(Optional) Related Tickets:

### Summary

### All Submissions
* [x] This PR has the JIRA linked.
* [x] Required tests are included.
* [x] No extemporaneous files are included (i.e Complied files or testing results).
* [x] This PR is merging into the **correct branch**.
* [x] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [x] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).
* [ ] All CDN/Web dependencies are hosted internally (i.e MADiE-Root Repo).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
