### PR TITLE
MAT-8231 Displaying CQL Errors or External CQL Errors only if their e…

### DIFF
--- a/src/components/editMeasure/EditMeasure.test.tsx
+++ b/src/components/editMeasure/EditMeasure.test.tsx
@@ -316,6 +316,7 @@ describe("EditMeasure Component", () => {
     const popCriteria = await screen.findByTestId("groups-tab");
     expect(popCriteria).toHaveAttribute("aria-selected", "true");
   });
+
   it("should render test-cases", async () => {
     renderRouter([{ pathname: "/measures/fakeid/edit/test-cases/" }]);
     const tcLink = await screen.findByTestId("patients-tab");

--- a/src/components/editMeasure/editor/MeasureEditor.tsx
+++ b/src/components/editMeasure/editor/MeasureEditor.tsx
@@ -241,8 +241,10 @@ const MeasureEditor = () => {
       // right now we are only displaying the external errors related to included libraries
       // and only the first error returned by elm translator
       if (errors?.length > 0 || externalErrors?.length > 0) {
-        const elmErrors = _.filter(errors, { errorSeverity: "Error" });
-        setError(!_.isEmpty(elmErrors) || externalErrors.length > 0);
+        setError(
+          !_.isEmpty(_.filter(errors, { errorSeverity: "Error" })) ||
+            !_.isEmpty(_.filter(externalErrors, { errorSeverity: "Error" }))
+        );
       }
       setErrorMessage(externalErrors[0]?.message);
       if (isLoggedInUMLS(errors)) {
@@ -376,7 +378,10 @@ const MeasureEditor = () => {
       const cqlElmErrors =
         !_.isEmpty(
           _.filter(validationResult?.errors, { errorSeverity: "Error" })
-        ) || !_.isEmpty(validationResult?.externalErrors);
+        ) ||
+        !_.isEmpty(
+          _.filter(validationResult?.externalErrors, { errorSeverity: "Error" })
+        );
 
       if (editorValue !== measure.cql) {
         const cqlErrors = parseErrors || cqlElmErrors;


### PR DESCRIPTION
…rrorSeverity is Error

## MADiE PR

Jira Ticket: [MAT-8231](https://jira.cms.gov/browse/MAT-8231)
(Optional) Related Tickets:

Summary

1. Diplaying if CQL has any errors
2. Displaying if CQL has any external Errors
3. Warnings are ignored as they don't have locator information https://github.com/cqframework/clinical_quality_language/issues/1492


### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included.
* [ ] No extemporaneous files are included (i.e Complied files or testing results).
* [ ] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).
* [ ] All CDN/Web dependencies are hosted internally (i.e MADiE-Root Repo).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
