### PR TITLE
MAT-8380 revert changes- fetching valuesets oid from related artifacts of effectiveDr

### DIFF
--- a/src/components/editMeasure/testCases/api/TerminologyServiceApi.test.ts
+++ b/src/components/editMeasure/testCases/api/TerminologyServiceApi.test.ts
@@ -5,7 +5,6 @@ import { officeVisitMeasureBundle } from "./__mocks__/OfficeVisitMeasureBundle";
 import { cqm_measure_basic } from "../mockdata/qdm/CMS108/cqm_measure_basic";
 import { cqm_measure_basic_valueset } from "../mockdata/qdm/CMS108/cqm_measure_basic_valueset";
 import { Measure as CqmMeasure, ValueSet } from "cqm-models";
-import { Measure as FHIRMeasure } from "fhir/r4";
 import * as _ from "lodash";
 import { ManifestExpansion } from "@madie/madie-models";
 
@@ -49,15 +48,6 @@ describe("TerminologyServiceApi Tests", () => {
         expect(data[0].id).toEqual("2.16.840.1.113883.3.464.1003.101.12.1001");
         expect(data[0].compose.include[0].concept.length).toEqual(5);
       });
-  });
-
-  it("gives empty expansion results if no value set found in bundle", () => {
-    const bundle = { ...officeVisitMeasureBundle };
-    const measure = bundle.entry[0].resource as FHIRMeasure;
-    measure.contained = [{} as fhir4.Library];
-    terminologyService.getValueSetsExpansionForBundle(bundle).then((data) => {
-      expect(data.length).toEqual(0);
-    });
   });
 
   it("throws an error if ValueSets not found in VSAC", async () => {
@@ -140,7 +130,10 @@ describe("TerminologyServiceApi Tests", () => {
           id: "mu2-update-2015-05-01",
         },
         activeOnly: "true",
-        valueSetParams: [{ oid: "2.16.840.1.113883.3.464.1003.1170" }],
+        valueSetParams: [
+          { oid: "2.16.840.1.113883.3.666.5.307" },
+          { oid: "2.16.840.1.113883.3.464.1003.103.12.1001" },
+        ],
       },
       { headers: { Authorization: "Bearer undefined" }, signal: true }
     );
@@ -161,7 +154,10 @@ describe("TerminologyServiceApi Tests", () => {
         includeDraft: "yes",
         manifestExpansion: null,
         activeOnly: "false",
-        valueSetParams: [{ oid: "2.16.840.1.113883.3.464.1003.1170" }],
+        valueSetParams: [
+          { oid: "2.16.840.1.113883.3.666.5.307" },
+          { oid: "2.16.840.1.113883.3.464.1003.103.12.1001" },
+        ],
       },
       { headers: { Authorization: "Bearer undefined" }, signal: true }
     );
@@ -185,7 +181,10 @@ describe("TerminologyServiceApi Tests", () => {
               id: "mu2-update-2015-05-01",
             },
             activeOnly: "true",
-            valueSetParams: [{ oid: "2.16.840.1.113883.3.464.1003.1170" }],
+            valueSetParams: [
+              { oid: "2.16.840.1.113883.3.666.5.307" },
+              { oid: "2.16.840.1.113883.3.464.1003.103.12.1001" },
+            ],
           },
           { headers: { Authorization: "Bearer undefined" }, signal: false }
         );
@@ -319,14 +318,6 @@ describe("TerminologyServiceApi Tests", () => {
         } as fhir4.BundleEntry,
       ],
     } as fhir4.Bundle;
-    const result = terminologyService.getValueSetsOIdsFromBundle(bundle);
-    expect(_.isEmpty(result)).toBe(true);
-  });
-
-  it("test getValueSetsOIdsFromBundle if module definition library not found", () => {
-    const bundle = { ...officeVisitMeasureBundle };
-    const measure = bundle.entry[0].resource as FHIRMeasure;
-    measure.contained = [];
     const result = terminologyService.getValueSetsOIdsFromBundle(bundle);
     expect(_.isEmpty(result)).toBe(true);
   });

--- a/src/components/editMeasure/testCases/api/__mocks__/OfficeVisitMeasureBundle.ts
+++ b/src/components/editMeasure/testCases/api/__mocks__/OfficeVisitMeasureBundle.ts
@@ -10,35 +10,6 @@ export const officeVisitMeasureBundle: fhir4.Bundle = {
             "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/proportion-measure-cqfm",
           ],
         },
-        contained: [
-          {
-            resourceType: "Library",
-            id: "SimpleFhirMeasureLib",
-            name: "EffectiveDataRequirements",
-            status: "active",
-            type: {
-              coding: [
-                {
-                  system: "http://terminology.hl7.org/CodeSystem/library-type",
-                  code: "module-definition",
-                },
-              ],
-            },
-            relatedArtifact: [
-              {
-                type: "depends-on",
-                display: "Library FHIRHelpers",
-                resource: "https://madie.cms.gov/Library/FHIRHelpers|4.4.000",
-              },
-              {
-                type: "depends-on",
-                display: "Value set Office Visit",
-                resource:
-                  "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001",
-              },
-            ],
-          },
-        ],
         url: "http://ecqi.healthit.gov/ecqms/Measure/SimpleFhirMeasureLib",
         version: "0",
         name: "SimpleFhirMeasureLib",

--- a/src/components/editMeasure/testCases/api/useTerminologyServiceApi.ts
+++ b/src/components/editMeasure/testCases/api/useTerminologyServiceApi.ts
@@ -1,8 +1,8 @@
 import axios from "../../../../api/axios-instance";
 import useServiceConfig from "../../../../api/useServiceConfig";
 import { ServiceConfig } from "../../../../api/ServiceContext";
-import { useOktaTokens } from "@madie/madie-util";
-import { Bundle, Library, Measure, ValueSet } from "fhir/r4";
+import { getOidFromString, useOktaTokens } from "@madie/madie-util";
+import { Bundle, Library, ValueSet } from "fhir/r4";
 import { CqmMeasure, CQL, ValueSet as QdmValueSet } from "cqm-models";
 import * as _ from "lodash";
 import md5 from "blueimp-md5";
@@ -141,41 +141,61 @@ export class TerminologyServiceApi {
   getValueSetsOIDsFromCqmMeasure(
     cqmMeasure: CqmMeasure
   ): ValueSetSearchParams[] {
-    return cqmMeasure?.source_data_criteria
-      ?.filter((criteria) => !criteria.codeListId.startsWith("drc-"))
-      .map((criteria) => {
-        return {
-          oid: criteria.codeListId,
-        } as ValueSetSearchParams;
-      });
+    const uniqueOids = new Set();
+    cqmMeasure?.cql_libraries?.forEach((library) => {
+      const valueSetDefs = library?.elm?.library?.valueSets?.def;
+      if (!_.isEmpty(valueSetDefs)) {
+        valueSetDefs.forEach((def) => {
+          if (def?.id) {
+            if (def.id.startsWith("urn:oid:")) {
+              const oid = getOidFromString(def.id, "QDM");
+              uniqueOids.add(oid);
+            } else {
+              uniqueOids.add(def?.id);
+            }
+          }
+        });
+      }
+    });
+    return _.map(Array.from(uniqueOids), (id: string) => ({
+      ["oid"]: id,
+    }));
   }
 
   /**
    * Extract the ValueSet OIDs used in measure & including libraries
    */
   getValueSetsOIdsFromBundle(measureBundle: Bundle): ValueSetSearchParams[] {
-    if (!measureBundle?.entry) {
-      return [];
+    if (measureBundle?.entry) {
+      return measureBundle.entry
+        .filter((entry) => entry.resource?.resourceType === "Library")
+        .reduce((allVs, library) => {
+          const libraryResource = library.resource as Library;
+          // TODO: this should be taken from dataRequirements. Using relatedArtifacts temporarily
+          // TODO: release and version not supported
+          const libVs = libraryResource.relatedArtifact?.reduce(
+            (libVs, artifact) => {
+              if (
+                artifact?.resource &&
+                artifact.resource.includes("/ValueSet/")
+              ) {
+                const oid = this.getOidFromString(artifact.resource);
+                if (oid) {
+                  libVs.push({ oid: oid });
+                }
+              }
+              return libVs;
+            },
+            [] as ValueSetSearchParams[]
+          );
+          if (libVs) {
+            return allVs.concat(libVs);
+          } else {
+            return allVs;
+          }
+        }, [] as ValueSetSearchParams[]);
     }
-    const measureEntry = measureBundle.entry.find(
-      (entry) => entry.resource?.resourceType === "Measure"
-    );
-    if (!measureEntry) {
-      return [];
-    }
-    const measure = measureEntry.resource as Measure;
-    const moduleDefinition = measure.contained as Library[];
-    if (!moduleDefinition?.length) {
-      return [];
-    }
-
-    return moduleDefinition[0].relatedArtifact?.reduce((oids, artifact) => {
-      if (artifact.resource?.includes("ValueSet/")) {
-        const valueSetOid = artifact.resource.split("/ValueSet/")[1];
-        oids.push({ oid: valueSetOid });
-      }
-      return oids;
-    }, [] as ValueSetSearchParams[]);
+    return [];
   }
 
   getOidFromString(oidString: string): string {

--- a/src/components/editMeasure/testCases/components/routes/qiCore/TestCaseRoutes.test.tsx
+++ b/src/components/editMeasure/testCases/components/routes/qiCore/TestCaseRoutes.test.tsx
@@ -649,18 +649,12 @@ describe("TestCaseRoutes", () => {
     measureBundle.entry = [
       {
         resource: {
-          resourceType: "Measure",
-          contained: [
+          resourceType: "Library",
+          relatedArtifact: [
             {
-              resourceType: "Library",
-              relatedArtifact: [
-                {
-                  type: "depends-on",
-                  display: "Value set Office Visit",
-                  resource:
-                    "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001",
-                },
-              ],
+              type: "depends-on",
+              resource:
+                "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.213",
             },
           ],
         } as any,


### PR DESCRIPTION
…

## MADiE PR

Jira Ticket: [MAT-8380](https://jira.cms.gov/browse/MAT-8380)
(Optional) Related Tickets:

### Summary

- effectiveDr contains only used value sets. fqm-execution expects both used and unused valuesets therfore reverting this change to fetch the valuesets from individual library's related artifacts that contains unused valuesets as well.
- was caused by [MAT-8380](https://jira.cms.gov/browse/MAT-8380)

### All Submissions
* [x] This PR has the JIRA linked.
* [x] Required tests are included.
* [x] No extemporaneous files are included (i.e Complied files or testing results).
* [x] This PR is merging into the **correct branch**.
* [x] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).
* [ ] All CDN/Web dependencies are hosted internally (i.e MADiE-Root Repo).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
