### PR TITLE
MAT-8571: display user friendly error message when a measure fails to…

### DIFF
--- a/src/components/editMeasure/EditMeasure.tsx
+++ b/src/components/editMeasure/EditMeasure.tsx
@@ -290,28 +290,29 @@ export default function EditMeasure() {
       );
     };
   }, [currentMeasureId]);
+
   const handleCreateError = (error) => {
     const errorData = error?.response;
+    const message = errorData?.data?.message;
+
     setToastOpen(true);
     setLoading(false);
     if (errorData?.status === 400) {
       setToastMessage("Requested measure cannot be versioned");
     } else if (errorData?.status === 403) {
       setToastMessage("User is unauthorized to create a version");
-    } else if (errorData?.status === 409) {
-      setToastMessage(
-        errorData?.data?.message
-          ? errorData.data.message
-          : "Requested operation could not be completed. Please contact the Help Desk."
-      );
     } else {
-      setToastMessage(errorData?.message ? errorData.message : "Server error!");
+      setToastMessage(
+        message ||
+          "Requested operation could not be completed. Please contact the Help Desk."
+      );
     }
-    const message = JSON.parse(errorData?.request?.responseText)?.message;
+
     if (message) {
       setVersionHelperText(versionErrorHelper(message));
     }
   };
+
   const handleDialogClose = () => {
     setInvalidTestCaseOpen(false);
     setCreateVersionDialog({

--- a/src/components/measureLanding/measureList/MeasureList.test.tsx
+++ b/src/components/measureLanding/measureList/MeasureList.test.tsx
@@ -27,6 +27,7 @@ import ServiceContext, { ServiceConfig } from "../../../api/ServiceContext";
 import { Simulate } from "react-dom/test-utils";
 // @ts-ignore
 import { useFeatureFlags, checkUserCanEdit } from "@madie/madie-util";
+import { AxiosError, AxiosResponse } from "axios";
 
 const EXPORT_FAILURE_MESSAGE =
   "Unable to Export measure. Package could not be generated. Please try again and contact the Help Desk if the problem persists.";
@@ -564,19 +565,7 @@ describe("Measure List component", () => {
   });
 
   it("Should display invalid Cql library name dialog and close on cancel.", async () => {
-    const error = {
-      response: {
-        status: 403,
-        request: {
-          responseText: JSON.stringify({
-            message: "User is unauthorized to create a version",
-          }),
-        },
-      },
-    };
     const useMeasureServiceMockRejected = {
-      createVersion: jest.fn().mockRejectedValue(error),
-      checkValidVersion: jest.fn().mockRejectedValue(error),
       checkNextVersionNumber: jest.fn().mockReturnValue("1.0.000"),
       fetchMeasure: jest.fn().mockResolvedValueOnce(badCqlLibraryName),
     } as unknown as MeasureServiceApi;
@@ -640,19 +629,22 @@ describe("Measure List component", () => {
   });
 
   it("should display unauthorized error while creating a version of a measure", async () => {
-    const error = {
+    const axiosError: AxiosError = {
       response: {
         status: 403,
-        request: {
-          responseText: JSON.stringify({
-            message: "User is unauthorized to create a version",
-          }),
+        data: {
+          timestamp: "2025-04-18T18:06:17.711+00:00",
+          message:
+            "User userId is not authorized for Measure with ID 680278565a582d3542b71eba",
+          status: 403,
+          error: "Forbidden",
         },
-      },
-    };
+      } as AxiosResponse,
+    } as AxiosError;
+
     const useMeasureServiceMockRejected = {
-      createVersion: jest.fn().mockRejectedValue(error),
-      checkValidVersion: jest.fn().mockRejectedValue(error),
+      createVersion: jest.fn().mockRejectedValue(axiosError),
+      checkValidVersion: jest.fn().mockRejectedValue(axiosError),
       checkNextVersionNumber: jest.fn().mockReturnValue("1.0.000"),
       fetchMeasure: jest.fn().mockResolvedValueOnce(measures[0]),
     } as unknown as MeasureServiceApi;
@@ -709,25 +701,32 @@ describe("Measure List component", () => {
       expect(getByTestId("error-toast")).toHaveTextContent(
         "User is unauthorized to create a version"
       );
+
+      expect(screen.getByTestId("version-helper-text")).toHaveTextContent(
+        "An unexpected error has occurred. Please contact the help desk."
+      );
     });
     unmount();
   });
 
-  it("should display bad request while creating a version of a measure", async () => {
-    const error = {
+  it("should display bad request error while creating a version of a measure in draft state", async () => {
+    const axiosError: AxiosError = {
       response: {
         status: 400,
-        request: {
-          responseText: JSON.stringify({
-            message: "Requested measure cannot be versioned",
-          }),
+        data: {
+          timestamp: "2025-04-18T18:06:17.711+00:00",
+          message:
+            "User userId cannot version Measure with ID 680278565a582d3542b71eba. Measure is not in a draft state.",
+          status: 400,
+          error: "Bad Request",
         },
-      },
-    };
+      } as AxiosResponse,
+    } as AxiosError;
+
     const useMeasureServiceMockRejected = {
-      createVersion: jest.fn().mockRejectedValue(error),
+      createVersion: jest.fn().mockRejectedValue(axiosError),
       checkNextVersionNumber: jest.fn().mockReturnValue("1.0.000"),
-      checkValidVersion: jest.fn().mockRejectedValue(error),
+      checkValidVersion: jest.fn().mockRejectedValue(axiosError),
       fetchMeasure: jest.fn().mockResolvedValueOnce(measures[0]),
     } as unknown as MeasureServiceApi;
 
@@ -783,26 +782,275 @@ describe("Measure List component", () => {
       expect(getByTestId("error-toast")).toHaveTextContent(
         "Requested measure cannot be versioned"
       );
+
+      expect(screen.getByTestId("version-helper-text")).toHaveTextContent(
+        "Please ensure the measure is first in draft state before versioning this measure."
+      );
     });
     unmount();
   });
 
-  it("should display other error while creating a version of a measure", async () => {
-    const error = {
+  it("should display bad request error while creating a version of a measure with no CQL", async () => {
+    const axiosError: AxiosError = {
+      response: {
+        status: 400,
+        data: {
+          timestamp: "2025-04-18T18:06:17.711+00:00",
+          message:
+            "User userId cannot version Measure with ID 680278565a582d3542b71eba. Measure has no CQL.",
+          status: 400,
+          error: "Bad Request",
+        },
+      } as AxiosResponse,
+    } as AxiosError;
+
+    const useMeasureServiceMockRejected = {
+      createVersion: jest.fn().mockRejectedValue(axiosError),
+      checkNextVersionNumber: jest.fn().mockReturnValue("1.0.000"),
+      checkValidVersion: jest.fn().mockRejectedValue(axiosError),
+      fetchMeasure: jest.fn().mockResolvedValueOnce(measures[0]),
+    } as unknown as MeasureServiceApi;
+
+    useMeasureServiceMock.mockImplementation(() => {
+      return useMeasureServiceMockRejected;
+    });
+
+    const { getByTestId, unmount } = render(
+      <ServiceContext.Provider value={serviceConfig}>
+        <MeasureList
+          measureList={measures}
+          setMeasureList={setMeasureListMock}
+          setTotalPages={setTotalPagesMock}
+          setTotalItems={setTotalItemsMock}
+          setVisibleItems={setVisibleItemsMock}
+          setOffset={setOffsetMock}
+          setLoading={setLoadingMock}
+          activeTab={0}
+          searchCriteria={""}
+          setSearchCriteria={setSearchCriteriaMock}
+          currentLimit={10}
+          currentPage={0}
+          setErrMsg={setErrMsgMock}
+        />
+      </ServiceContext.Provider>
+    );
+    const checkBoxes = await screen.findAllByRole("checkbox");
+    expect(checkBoxes.length).toBe(5);
+    userEvent.click(checkBoxes[1]);
+    const createVersionButton = getByTestId("version-action-btn");
+    expect(createVersionButton).toBeInTheDocument();
+    userEvent.click(createVersionButton);
+    expect(getByTestId("create-version-dialog")).toBeInTheDocument();
+
+    const typeInput = screen.getByTestId(
+      "version-type-input"
+    ) as HTMLInputElement;
+    expect(typeInput).toBeInTheDocument();
+    expect(typeInput.value).toBe("");
+    fireEvent.change(typeInput, {
+      target: { value: "major" },
+    });
+    expect(typeInput.value).toBe("major");
+    const confirmVersionNode = getByTestId(
+      "confirm-version-input"
+    ) as HTMLInputElement;
+    userEvent.type(confirmVersionNode, "1.0.000");
+    Simulate.change(confirmVersionNode);
+    expect(confirmVersionNode.value).toBe("1.0.000");
+
+    await waitFor(() => {
+      userEvent.click(getByTestId("create-version-continue-button"));
+      expect(getByTestId("error-toast")).toHaveTextContent(
+        "Requested measure cannot be versioned"
+      );
+
+      expect(screen.getByTestId("version-helper-text")).toHaveTextContent(
+        "Please include valid CQL in the CQL editor to version before versioning this measure."
+      );
+    });
+    unmount();
+  });
+
+  it("should display bad request error while creating a version of a measure with CQL with errors", async () => {
+    const axiosError: AxiosError = {
+      response: {
+        status: 400,
+        data: {
+          timestamp: "2025-04-18T18:06:17.711+00:00",
+          message:
+            "User userId cannot version Measure with ID 680278565a582d3542b71eba. Measure has CQL errors.",
+          status: 400,
+          error: "Bad Request",
+        },
+      } as AxiosResponse,
+    } as AxiosError;
+
+    const useMeasureServiceMockRejected = {
+      createVersion: jest.fn().mockRejectedValue(axiosError),
+      checkNextVersionNumber: jest.fn().mockReturnValue("1.0.000"),
+      checkValidVersion: jest.fn().mockRejectedValue(axiosError),
+      fetchMeasure: jest.fn().mockResolvedValueOnce(measures[0]),
+    } as unknown as MeasureServiceApi;
+
+    useMeasureServiceMock.mockImplementation(() => {
+      return useMeasureServiceMockRejected;
+    });
+
+    const { getByTestId, unmount } = render(
+      <ServiceContext.Provider value={serviceConfig}>
+        <MeasureList
+          measureList={measures}
+          setMeasureList={setMeasureListMock}
+          setTotalPages={setTotalPagesMock}
+          setTotalItems={setTotalItemsMock}
+          setVisibleItems={setVisibleItemsMock}
+          setOffset={setOffsetMock}
+          setLoading={setLoadingMock}
+          activeTab={0}
+          searchCriteria={""}
+          setSearchCriteria={setSearchCriteriaMock}
+          currentLimit={10}
+          currentPage={0}
+          setErrMsg={setErrMsgMock}
+        />
+      </ServiceContext.Provider>
+    );
+    const checkBoxes = await screen.findAllByRole("checkbox");
+    expect(checkBoxes.length).toBe(5);
+    userEvent.click(checkBoxes[1]);
+    const createVersionButton = getByTestId("version-action-btn");
+    expect(createVersionButton).toBeInTheDocument();
+    userEvent.click(createVersionButton);
+    expect(getByTestId("create-version-dialog")).toBeInTheDocument();
+
+    const typeInput = screen.getByTestId(
+      "version-type-input"
+    ) as HTMLInputElement;
+    expect(typeInput).toBeInTheDocument();
+    expect(typeInput.value).toBe("");
+    fireEvent.change(typeInput, {
+      target: { value: "major" },
+    });
+    expect(typeInput.value).toBe("major");
+    const confirmVersionNode = getByTestId(
+      "confirm-version-input"
+    ) as HTMLInputElement;
+    userEvent.type(confirmVersionNode, "1.0.000");
+    Simulate.change(confirmVersionNode);
+    expect(confirmVersionNode.value).toBe("1.0.000");
+
+    await waitFor(() => {
+      userEvent.click(getByTestId("create-version-continue-button"));
+      expect(getByTestId("error-toast")).toHaveTextContent(
+        "Requested measure cannot be versioned"
+      );
+
+      expect(screen.getByTestId("version-helper-text")).toHaveTextContent(
+        "Please include valid CQL in the CQL editor to version before versioning this measure."
+      );
+    });
+    unmount();
+  });
+
+  it("should display bad request error while creating a version of a measure with no population criteria", async () => {
+    const axiosError: AxiosError = {
+      response: {
+        status: 400,
+        data: {
+          timestamp: "2025-04-18T18:06:17.711+00:00",
+          message:
+            "User userId cannot version Measure with ID 680278565a582d3542b71eba. Measure does not have at least one Population Criteria.",
+          status: 400,
+          error: "Bad Request",
+        },
+      } as AxiosResponse,
+    } as AxiosError;
+
+    const useMeasureServiceMockRejected = {
+      createVersion: jest.fn().mockRejectedValue(axiosError),
+      checkNextVersionNumber: jest.fn().mockReturnValue("1.0.000"),
+      checkValidVersion: jest.fn().mockRejectedValue(axiosError),
+      fetchMeasure: jest.fn().mockResolvedValueOnce(measures[0]),
+    } as unknown as MeasureServiceApi;
+
+    useMeasureServiceMock.mockImplementation(() => {
+      return useMeasureServiceMockRejected;
+    });
+
+    const { getByTestId, unmount } = render(
+      <ServiceContext.Provider value={serviceConfig}>
+        <MeasureList
+          measureList={measures}
+          setMeasureList={setMeasureListMock}
+          setTotalPages={setTotalPagesMock}
+          setTotalItems={setTotalItemsMock}
+          setVisibleItems={setVisibleItemsMock}
+          setOffset={setOffsetMock}
+          setLoading={setLoadingMock}
+          activeTab={0}
+          searchCriteria={""}
+          setSearchCriteria={setSearchCriteriaMock}
+          currentLimit={10}
+          currentPage={0}
+          setErrMsg={setErrMsgMock}
+        />
+      </ServiceContext.Provider>
+    );
+    const checkBoxes = await screen.findAllByRole("checkbox");
+    expect(checkBoxes.length).toBe(5);
+    userEvent.click(checkBoxes[1]);
+    const createVersionButton = getByTestId("version-action-btn");
+    expect(createVersionButton).toBeInTheDocument();
+    userEvent.click(createVersionButton);
+    expect(getByTestId("create-version-dialog")).toBeInTheDocument();
+
+    const typeInput = screen.getByTestId(
+      "version-type-input"
+    ) as HTMLInputElement;
+    expect(typeInput).toBeInTheDocument();
+    expect(typeInput.value).toBe("");
+    fireEvent.change(typeInput, {
+      target: { value: "major" },
+    });
+    expect(typeInput.value).toBe("major");
+    const confirmVersionNode = getByTestId(
+      "confirm-version-input"
+    ) as HTMLInputElement;
+    userEvent.type(confirmVersionNode, "1.0.000");
+    Simulate.change(confirmVersionNode);
+    expect(confirmVersionNode.value).toBe("1.0.000");
+
+    await waitFor(() => {
+      userEvent.click(getByTestId("create-version-continue-button"));
+      expect(getByTestId("error-toast")).toHaveTextContent(
+        "Requested measure cannot be versioned"
+      );
+
+      expect(screen.getByTestId("version-helper-text")).toHaveTextContent(
+        "Please set up at least one Population Criteria before versioning this measure."
+      );
+    });
+    unmount();
+  });
+
+  it("should display server error message if returned while creating a version of a measure", async () => {
+    const axiosError: AxiosError = {
       response: {
         status: 500,
-        message: "server error",
-        request: {
-          responseText: JSON.stringify({
-            message: "Requested measure cannot be versioned",
-          }),
+        data: {
+          timestamp: "2025-04-18T18:06:17.711+00:00",
+          message:
+            "User userId cannot version Measure with ID 680278565a582d3542b71eba. A server related error occurred.",
+          status: 500,
+          error: "Internal Server Error",
         },
-      },
-    };
+      } as AxiosResponse,
+    } as AxiosError;
+
     const useMeasureServiceMockRejected = {
-      createVersion: jest.fn().mockRejectedValue(error),
+      createVersion: jest.fn().mockRejectedValue(axiosError),
       checkNextVersionNumber: jest.fn().mockReturnValue("1.0.000"),
-      checkValidVersion: jest.fn().mockRejectedValue(error),
+      checkValidVersion: jest.fn().mockRejectedValue(axiosError),
       fetchMeasure: jest.fn().mockResolvedValueOnce(measures[0]),
     } as unknown as MeasureServiceApi;
 
@@ -854,7 +1102,13 @@ describe("Measure List component", () => {
     expect(confirmVersionNode.value).toBe("1.0.000");
     await waitFor(() => {
       userEvent.click(getByTestId("create-version-continue-button"));
-      expect(getByTestId("error-toast")).toHaveTextContent("server error");
+      expect(getByTestId("error-toast")).toHaveTextContent(
+        "User userId cannot version Measure with ID 680278565a582d3542b71eba. A server related error occurred."
+      );
+
+      expect(screen.getByTestId("version-helper-text")).toHaveTextContent(
+        "An unexpected error has occurred. Please contact the help desk."
+      );
     });
     unmount();
   });

--- a/src/components/measureLanding/measureList/MeasureList.tsx
+++ b/src/components/measureLanding/measureList/MeasureList.tsx
@@ -683,22 +683,21 @@ export default function MeasureList(props: {
 
   const handleCreateError = (error) => {
     const errorData = error?.response;
+    const message = errorData?.data?.message;
+
     setToastOpen(true);
     setLoading(false);
     if (errorData?.status === 400) {
       setToastMessage("Requested measure cannot be versioned");
     } else if (errorData?.status === 403) {
       setToastMessage("User is unauthorized to create a version");
-    } else if (errorData?.status === 409) {
-      setToastMessage(
-        errorData?.data?.message
-          ? errorData.data.message
-          : "Requested operation could not be completed. Please contact the Help Desk."
-      );
     } else {
-      setToastMessage(errorData?.message ? errorData.message : "Server error!");
+      setToastMessage(
+        message ||
+          "Requested operation could not be completed. Please contact the Help Desk."
+      );
     }
-    const message = JSON.parse(errorData?.request?.responseText)?.message;
+
     if (message) {
       setVersionHelperText(versionErrorHelper(message));
     }

--- a/src/utils/versionErrorHelper.test.tsx
+++ b/src/utils/versionErrorHelper.test.tsx
@@ -28,6 +28,13 @@ describe("Versioning error helper", () => {
       "Please include valid test cases to version before versioning this measure."
     );
   });
+  it("should return expected output for no Population Criteria error", () => {
+    expect(
+      versionErrorHelper("does not have at least one Population Criteria")
+    ).toBe(
+      "Please set up at least one Population Criteria before versioning this measure."
+    );
+  });
   it("should return expected output for non caught cases", () => {
     expect(versionErrorHelper("test")).toBe(
       "An unexpected error has occurred. Please contact the help desk."

--- a/src/utils/versionErrorHelper.tsx
+++ b/src/utils/versionErrorHelper.tsx
@@ -21,5 +21,11 @@ export default function versionErrorHelper(errorMessage: string): string {
     humanReadbleOutput =
       "Please include valid test cases to version before versioning this measure.";
   }
+  // "User [{}] attempted to version measure with id [{}] which does not have at least one Population Criteria"
+  if (errorMessage.includes("does not have at least one Population Criteria")) {
+    humanReadbleOutput =
+      "Please set up at least one Population Criteria before versioning this measure.";
+  }
+
   return humanReadbleOutput;
 }


### PR DESCRIPTION
… version because the measure does not have at least one Population Criteria; improve error handling for create version dialog

## MADiE PR

Jira Ticket: [MAT-8571](https://jira.cms.gov/browse/MAT-8571)
(Optional) Related Tickets:

### Summary

### All Submissions
* [x] This PR has the JIRA linked.
* [x] Required tests are included.
* [x] No extemporaneous files are included (i.e Complied files or testing results).
* [x] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).
* [ ] All CDN/Web dependencies are hosted internally (i.e MADiE-Root Repo).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
