### PR TITLE
[MAT-8490] QI-Core Test Case: Display JSON parse error message in error banner

### DIFF
--- a/src/components/editMeasure/testCases/components/editTestCase/qiCore/EditTestCase.test.tsx
+++ b/src/components/editMeasure/testCases/components/editTestCase/qiCore/EditTestCase.test.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { ChangeEvent } from "react";
 import {
+  act,
   fireEvent,
   render,
   screen,
@@ -31,7 +32,6 @@ import {
   TestCase,
 } from "@madie/madie-models";
 import TestCaseRoutes from "../../routes/qiCore/TestCaseRoutes";
-import { act } from "react-dom/test-utils";
 import { PopulationEpisodeResult } from "../../../api/CalculationService";
 import { simpleMeasureFixture } from "../../createTestCase/__mocks__/simpleMeasureFixture";
 import { testCaseFixture } from "../../createTestCase/__mocks__/testCaseFixture";

--- a/src/components/editMeasure/testCases/components/editTestCase/qiCore/EditTestCase.tsx
+++ b/src/components/editMeasure/testCases/components/editTestCase/qiCore/EditTestCase.tsx
@@ -367,6 +367,10 @@ const EditTestCase = (props: EditTestCaseProps) => {
         return JSON.stringify(JSON.parse(testCase.json), null, 2);
       }
     } catch (e) {
+      setErrors([
+        ...errors,
+        "Test Case JSON contains a syntax error. Test case can be saved, but not run.",
+      ]);
       return testCase?.json;
     }
   };


### PR DESCRIPTION
## MADiE PR

Jira Ticket: [MAT-8490](https://jira.cms.gov/browse/MAT-8490)
(Optional) Related Tickets:

### Summary

Edit qicore test case: display json parse error message in error banner. The parse check was already happening. This simply adds a static message to the error banner on parse exception.

![Screenshot 2025-04-21 at 9 35 57 AM](https://github.com/user-attachments/assets/53f12f3a-e251-44c5-9f57-118efdd2194b)

### All Submissions

* [ ] This PR has the JIRA linked.
* [ ] Required tests are included.
* [ ] No extemporaneous files are included (i.e Complied files or testing results).
* [ ] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).
* [ ] All CDN/Web dependencies are hosted internally (i.e MADiE-Root Repo).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
