### PR TITLE
MAT-8793: Handle deletion of QDM Entities as Data Element Attributes.

### DIFF
--- a/src/components/editMeasure/testCases/components/editTestCase/qdm/LeftPanel/ElementsTab/Elements/DataElementsCard/DataElementsCard.tsx
+++ b/src/components/editMeasure/testCases/components/editTestCase/qdm/LeftPanel/ElementsTab/Elements/DataElementsCard/DataElementsCard.tsx
@@ -59,7 +59,7 @@ export const deleteAttribute = (chip, dataElement) => {
       } else {
         updatedDataElement[attributePath] = _.filter(
           updatedDataElement[attributePath],
-          (a) => a.id !== chip.id
+          (a) => (a._id?.valueOf() ? a._id?.valueOf() : a.id) !== chip.id
         );
       }
     }


### PR DESCRIPTION
## MADiE PR

Jira Ticket: [MAT-8793](https://jira.cms.gov/browse/MAT-8793)
(Optional) Related Tickets:

### Summary

In addition to the generated Attribute id, QDM Entities have their own `id` field, causing confusion in the Attribute deletion logic which expected a single `id` field. This update will have the deletion logic check the internal `_id` field when available, and fallback to the `id` if not. 

### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included.
* [ ] No extemporaneous files are included (i.e Complied files or testing results).
* [ ] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).
* [ ] All CDN/Web dependencies are hosted internally (i.e MADiE-Root Repo).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
