### PR TITLE
MAT-8611: display blue dot indicator icon on a test case only when th…

### DIFF
--- a/src/components/editMeasure/testCases/components/testCaseLanding/common/TestCaseTable/TestCaseTable.test.tsx
+++ b/src/components/editMeasure/testCases/components/testCaseLanding/common/TestCaseTable/TestCaseTable.test.tsx
@@ -49,7 +49,7 @@ const testCaseInvalid = {
   title: "TEST IPP3",
   description: "TEST DESCRIPTION3",
   series: "TEST SERIES3",
-  lastModifiedAt: "2024-09-06T15:18:14.382Z",
+  lastModifiedAt: "2022-03-01T14:18:14.382Z",
   executionStatus: "Invalid",
   caseNumber: null,
 } as unknown as TestCase;
@@ -94,7 +94,7 @@ const measures = [
     cql: null,
     createdAt: null,
     createdBy: "testuser",
-    lastModifiedAt: null,
+    lastModifiedAt: "2023-05-01T14:18:14.382Z",
     lastModifiedBy: null,
     model: Model.QDM_5_6,
     active: true,
@@ -117,7 +117,7 @@ const measures = [
     cql: null,
     createdAt: null,
     createdBy: "testuser",
-    lastModifiedAt: null,
+    lastModifiedAt: "2023-05-01T14:18:14.382Z",
     lastModifiedBy: null,
     model: Model.QDM_5_6,
     active: true,
@@ -517,7 +517,36 @@ describe("TestCase component", () => {
     });
   });
 
-  it("should display FiberManualRecord icon when the EditTestsOnVersionedMeasures feature flag is true, draft is false, createdBeforeVersioning is false (all icon conditions are true)", async () => {
+  it("should not display FiberManualRecord icon when the EditTestsOnVersionedMeasures feature flag is false", async () => {
+    (useFeatureFlags as jest.Mock).mockClear().mockImplementation(() => ({
+      EditTestsOnVersionedMeasures: false,
+    }));
+
+    const deleteTestCase = jest.fn();
+    const exportTestCase = jest.fn();
+    const onCloneTestCase = jest.fn();
+    const setSelectedTestCasesMock = jest.fn();
+
+    renderWithTestCase(
+      [testCase],
+      true,
+      deleteTestCase,
+      exportTestCase,
+      onCloneTestCase,
+      measures[1],
+      setSelectedTestCasesMock
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId(
+          `test-case-fiber-manual-record-icon-${testCases[0].id}`
+        )
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it("should not display FiberManualRecord icon when draft is false", async () => {
     (useFeatureFlags as jest.Mock).mockClear().mockImplementation(() => ({
       EditTestsOnVersionedMeasures: true,
     }));
@@ -528,7 +557,65 @@ describe("TestCase component", () => {
     const setSelectedTestCasesMock = jest.fn();
 
     renderWithTestCase(
-      [{ ...testCase, action: { createdBeforeVersioning: false } }],
+      [testCase],
+      true,
+      deleteTestCase,
+      exportTestCase,
+      onCloneTestCase,
+      measures[2],
+      setSelectedTestCasesMock
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId(
+          `test-case-fiber-manual-record-icon-${testCases[0].id}`
+        )
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it("should not display FiberManualRecord icon when the test case was created or modified before the measure was last versioned", async () => {
+    (useFeatureFlags as jest.Mock).mockClear().mockImplementation(() => ({
+      EditTestsOnVersionedMeasures: true,
+    }));
+
+    const deleteTestCase = jest.fn();
+    const exportTestCase = jest.fn();
+    const onCloneTestCase = jest.fn();
+    const setSelectedTestCasesMock = jest.fn();
+
+    renderWithTestCase(
+      [testCaseFail],
+      true,
+      deleteTestCase,
+      exportTestCase,
+      onCloneTestCase,
+      measures[1],
+      setSelectedTestCasesMock
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId(
+          `test-case-fiber-manual-record-icon-${testCases[0].id}`
+        )
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it("should display FiberManualRecord icon when the EditTestsOnVersionedMeasures feature flag is true, draft is false, and the test case was created or modified after the measure was last versioned", async () => {
+    (useFeatureFlags as jest.Mock).mockClear().mockImplementation(() => ({
+      EditTestsOnVersionedMeasures: true,
+    }));
+
+    const deleteTestCase = jest.fn();
+    const exportTestCase = jest.fn();
+    const onCloneTestCase = jest.fn();
+    const setSelectedTestCasesMock = jest.fn();
+
+    renderWithTestCase(
+      [testCase],
       true,
       deleteTestCase,
       exportTestCase,
@@ -543,151 +630,6 @@ describe("TestCase component", () => {
           `test-case-fiber-manual-record-icon-${testCases[0].id}`
         )
       ).toBeInTheDocument();
-    });
-  });
-
-  it("should not display FiberManualRecord icon when the EditTestsOnVersionedMeasures feature flag is false, draft is false, createdBeforeVersioning is false", async () => {
-    (useFeatureFlags as jest.Mock).mockClear().mockImplementation(() => ({
-      EditTestsOnVersionedMeasures: false,
-    }));
-
-    const deleteTestCase = jest.fn();
-    const exportTestCase = jest.fn();
-    const onCloneTestCase = jest.fn();
-    const setSelectedTestCasesMock = jest.fn();
-
-    renderWithTestCase(
-      [{ ...testCase, action: { createdBeforeVersioning: false } }],
-      true,
-      deleteTestCase,
-      exportTestCase,
-      onCloneTestCase,
-      measures[1],
-      setSelectedTestCasesMock
-    );
-
-    await waitFor(() => {
-      expect(
-        screen.queryByTestId(
-          `test-case-fiber-manual-record-icon-${testCases[0].id}`
-        )
-      ).not.toBeInTheDocument();
-    });
-  });
-
-  it("should not display FiberManualRecord icon when the EditTestsOnVersionedMeasures feature flag is true, draft is true, createdBeforeVersioning is false", async () => {
-    (useFeatureFlags as jest.Mock).mockClear().mockImplementation(() => ({
-      EditTestsOnVersionedMeasures: true,
-    }));
-
-    const deleteTestCase = jest.fn();
-    const exportTestCase = jest.fn();
-    const onCloneTestCase = jest.fn();
-    const setSelectedTestCasesMock = jest.fn();
-
-    renderWithTestCase(
-      [{ ...testCase, action: { createdBeforeVersioning: false } }],
-      true,
-      deleteTestCase,
-      exportTestCase,
-      onCloneTestCase,
-      measures[2],
-      setSelectedTestCasesMock
-    );
-
-    await waitFor(() => {
-      expect(
-        screen.queryByTestId(
-          `test-case-fiber-manual-record-icon-${testCases[0].id}`
-        )
-      ).not.toBeInTheDocument();
-    });
-  });
-
-  it("should not display FiberManualRecord icon when the EditTestsOnVersionedMeasures feature flag is true, draft is false, createdBeforeVersioning is true", async () => {
-    (useFeatureFlags as jest.Mock).mockClear().mockImplementation(() => ({
-      EditTestsOnVersionedMeasures: true,
-    }));
-
-    const deleteTestCase = jest.fn();
-    const exportTestCase = jest.fn();
-    const onCloneTestCase = jest.fn();
-    const setSelectedTestCasesMock = jest.fn();
-
-    renderWithTestCase(
-      [{ ...testCase, action: { createdBeforeVersioning: false } }],
-      true,
-      deleteTestCase,
-      exportTestCase,
-      onCloneTestCase,
-      measures[2],
-      setSelectedTestCasesMock
-    );
-
-    await waitFor(() => {
-      expect(
-        screen.queryByTestId(
-          `test-case-fiber-manual-record-icon-${testCases[0].id}`
-        )
-      ).not.toBeInTheDocument();
-    });
-  });
-
-  it("should not display FiberManualRecord icon when the EditTestsOnVersionedMeasures feature flag is true, draft is false, createdBeforeVersioning is true", async () => {
-    (useFeatureFlags as jest.Mock).mockClear().mockImplementation(() => ({
-      EditTestsOnVersionedMeasures: true,
-    }));
-
-    const deleteTestCase = jest.fn();
-    const exportTestCase = jest.fn();
-    const onCloneTestCase = jest.fn();
-    const setSelectedTestCasesMock = jest.fn();
-
-    renderWithTestCase(
-      [{ ...testCase, action: { createdBeforeVersioning: true } }],
-      true,
-      deleteTestCase,
-      exportTestCase,
-      onCloneTestCase,
-      measures[2],
-      setSelectedTestCasesMock
-    );
-
-    await waitFor(() => {
-      expect(
-        screen.queryByTestId(
-          `test-case-fiber-manual-record-icon-${testCases[0].id}`
-        )
-      ).not.toBeInTheDocument();
-    });
-  });
-
-  it("should not display FiberManualRecord icon when the EditTestsOnVersionedMeasures feature flag is false, draft is true, createdBeforeVersioning is true (all icon conditions are false)", async () => {
-    (useFeatureFlags as jest.Mock).mockClear().mockImplementation(() => ({
-      EditTestsOnVersionedMeasures: false,
-    }));
-
-    const deleteTestCase = jest.fn();
-    const exportTestCase = jest.fn();
-    const onCloneTestCase = jest.fn();
-    const setSelectedTestCasesMock = jest.fn();
-
-    renderWithTestCase(
-      [{ ...testCase, action: { createdBeforeVersioning: true } }],
-      true,
-      deleteTestCase,
-      exportTestCase,
-      onCloneTestCase,
-      measures[2],
-      setSelectedTestCasesMock
-    );
-
-    await waitFor(() => {
-      expect(
-        screen.queryByTestId(
-          `test-case-fiber-manual-record-icon-${testCases[0].id}`
-        )
-      ).not.toBeInTheDocument();
     });
   });
 });

--- a/src/components/editMeasure/testCases/components/testCaseLanding/common/TestCaseTable/TestCaseTable.tsx
+++ b/src/components/editMeasure/testCases/components/testCaseLanding/common/TestCaseTable/TestCaseTable.tsx
@@ -69,6 +69,17 @@ export const convertDate = (date: string) => {
   };
 };
 
+// Returns true if the test case was created or modified after the measure was last versioned
+const isCreatedOrModifiedAfterVersioning = (
+  testCaseLastModifiedDateStr: string,
+  measureLastModifiedDateStr: string
+) => {
+  const testCaseLastModifiedDate = new Date(testCaseLastModifiedDateStr);
+  const measureLastModifiedDate = new Date(measureLastModifiedDateStr);
+
+  return testCaseLastModifiedDate > measureLastModifiedDate;
+};
+
 const IndeterminateCheckbox = ({ indeterminate, checked, ...rest }: any) => {
   const ref = React.useRef<HTMLInputElement>(null);
 
@@ -263,7 +274,10 @@ const TestCaseTable = (props: TestCaseTableProps) => {
             >
               {featureFlags?.EditTestsOnVersionedMeasures &&
               !measure.measureMetaData?.draft &&
-              !info.row.original.action.createdBeforeVersioning ? (
+              isCreatedOrModifiedAfterVersioning(
+                info.row.original.lastSaved,
+                measure?.lastModifiedAt
+              ) ? (
                 <div>
                   <FiberManualRecord
                     sx={fiberManualRecordStyles}


### PR DESCRIPTION
…e EditTestsOnVersionedMeasures feature flag is true, draft is false (measure is versioned), and the test case was created or modified after the measure was last versioned

## MADiE PR

Jira Ticket: [MAT-8611](https://jira.cms.gov/browse/MAT-8611)
(Optional) Related Tickets:

### Summary

### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included.
* [ ] No extemporaneous files are included (i.e Complied files or testing results).
* [ ] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).
* [ ] All CDN/Web dependencies are hosted internally (i.e MADiE-Root Repo).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
