### PR TITLE
MAT-8828: switch to using RichTextEditor (with readOnly true) so that…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@lhncbc/ucum-lhc": "^4.1.5",
         "@madie/cql-antlr-parser": "^1.0.11",
         "@madie/madie-auth": "^0.0.1",
-        "@madie/madie-design-system": "^1.2.68",
+        "@madie/madie-design-system": "^1.2.70",
         "@madie/madie-editor": "^0.0.1",
         "@madie/madie-models": "^1.4.41",
         "@madie/madie-root": "^0.0.3",
@@ -4447,9 +4447,9 @@
       }
     },
     "node_modules/@madie/madie-design-system": {
-      "version": "1.2.68",
-      "resolved": "https://registry.npmjs.org/@madie/madie-design-system/-/madie-design-system-1.2.68.tgz",
-      "integrity": "sha512-HHVZwZPUjSUWRpEp7SiMHoh8obhHHYk+3E/B1CIQ/pBsJs5ehQlnz6xzp/tfSF79A4C1uB8JG4D2i6u2o2f/YQ==",
+      "version": "1.2.70",
+      "resolved": "https://registry.npmjs.org/@madie/madie-design-system/-/madie-design-system-1.2.70.tgz",
+      "integrity": "sha512-IJOYH5pfihmAazlOxAzvfvhFoRZTUS6J76Emg3xeaH/nEilrHDxaSaGhPVJrvVV0A12PjfShzlRjo0zefehblg==",
       "license": "CC0-1.0",
       "dependencies": {
         "@cmsgov/design-system": "^5.0.2",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "@lhncbc/ucum-lhc": "^4.1.5",
     "@madie/cql-antlr-parser": "^1.0.11",
     "@madie/madie-auth": "^0.0.1",
-    "@madie/madie-design-system": "^1.2.68",
+    "@madie/madie-design-system": "^1.2.70",
     "@madie/madie-editor": "^0.0.1",
     "@madie/madie-models": "^1.4.41",
     "@madie/madie-root": "^0.0.3",

--- a/src/components/editMeasure/details/MeasureMetaDataRow.scss
+++ b/src/components/editMeasure/details/MeasureMetaDataRow.scss
@@ -1,3 +1,4 @@
+//preserve spacing/line breaks
 .read-only-description {
   white-space: pre-wrap;
 }

--- a/src/components/editMeasure/details/MeasureMetaDataRow.scss
+++ b/src/components/editMeasure/details/MeasureMetaDataRow.scss
@@ -1,4 +1,4 @@
-//preserve spacing/line breaks
+/* preserve spacing/line breaks */
 .read-only-description {
   white-space: pre-wrap;
 }

--- a/src/components/editMeasure/details/MeasureMetaDataRow.test.tsx
+++ b/src/components/editMeasure/details/MeasureMetaDataRow.test.tsx
@@ -13,10 +13,10 @@ jest.mock("@madie/madie-util", () => ({
   }),
 }));
 
-const testDescription = `"this is a statement
+const testDescription = `this is a statement
       this is a statement
-           this is a statement"`;
-const testDescriptionWithHtml = `"<p>this is a statement</p><p><strong>this is a statement</strong></p><p><u>this is a statement</u></p>"`;
+           this is a statement`;
+const testDescriptionWithHtml = `<p>this is a statement</p><p><strong>this is a statement</strong></p><p><u>this is a statement</u></p>`;
 const measureDefinitionRowId = "cdbf1bb6-2c18-4edb-ae57-123a1f263633";
 
 describe("Measure MetaData Row Component", () => {
@@ -62,11 +62,16 @@ describe("Measure MetaData Row Component", () => {
     expect(name).toBeInTheDocument();
 
     const richTextReadOnlyDescription = screen.getByTestId(
-      `measure-reference-${measureDefinitionRowId}-description`
+      "measure-reference-rich-text-editor"
     );
     expect(richTextReadOnlyDescription).toBeInTheDocument();
-    expect(richTextReadOnlyDescription).toHaveAttribute("role", "document");
-    expect(richTextReadOnlyDescription.innerHTML).toEqual(testDescription);
+
+    const paragraph = richTextReadOnlyDescription.querySelector("p");
+    expect(paragraph).toBeInTheDocument();
+
+    expect(paragraph.innerHTML).toBe(
+      "this is a statement\n      this is a statement\n           this is a statement"
+    );
   });
 
   it("Measure MetaData rows renders Measure Reference with description (with html in description) if EnhancedTextFormatting flag is true", async () => {
@@ -86,12 +91,18 @@ describe("Measure MetaData Row Component", () => {
     expect(name).toBeInTheDocument();
 
     const richTextReadOnlyDescription = screen.getByTestId(
-      `measure-reference-${measureDefinitionRowId}-description`
+      "measure-reference-rich-text-editor"
     );
     expect(richTextReadOnlyDescription).toBeInTheDocument();
-    expect(richTextReadOnlyDescription).toHaveAttribute("role", "document");
-    expect(richTextReadOnlyDescription.innerHTML).toEqual(
-      testDescriptionWithHtml
+
+    expect(richTextReadOnlyDescription).toContainHTML(
+      "<p>this is a statement</p>"
+    );
+    expect(richTextReadOnlyDescription).toContainHTML(
+      "<p><strong>this is a statement</strong></p>"
+    );
+    expect(richTextReadOnlyDescription).toContainHTML(
+      "<p><u>this is a statement</u></p>"
     );
   });
 

--- a/src/components/editMeasure/details/MeasureMetaDataRow.tsx
+++ b/src/components/editMeasure/details/MeasureMetaDataRow.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import "twin.macro";
 import "styled-components/macro";
-import { Popover } from "@madie/madie-design-system/dist/react";
+import { RichTextEditor } from "@madie/madie-design-system/dist/react";
 import DeleteOutlinedIcon from "@mui/icons-material/DeleteOutlined";
 import BorderColorOutlinedIcon from "@mui/icons-material/BorderColorOutlined";
 import { blue, red } from "@mui/material/colors";
@@ -10,7 +10,6 @@ import { Tooltip } from "@mui/material";
 import { useFeatureFlags } from "@madie/madie-util";
 import DOMPurify from "dompurify";
 import "./MeasureMetaDataRow.scss";
-
 interface MeasureMetaDataRowProps {
   name: string;
   description: string;
@@ -31,14 +30,11 @@ const MeasureMetaDataRow = (props: MeasureMetaDataRowProps) => {
 
         {featureFlags.EnhancedTextFormatting ? (
           <td>
-            <div
-              role="document"
-              className="read-only-description"
+            <RichTextEditor
+              id={name}
+              readOnly
+              content={description}
               data-testid={`measure-${type}-${id}-description`}
-              aria-labelledby={`${id}-label`}
-              dangerouslySetInnerHTML={{
-                __html: DOMPurify.sanitize(description),
-              }}
             />
           </td>
         ) : (

--- a/src/components/editMeasure/populationCriteria/groups/observation/MeasureGroupObservation.test.tsx
+++ b/src/components/editMeasure/populationCriteria/groups/observation/MeasureGroupObservation.test.tsx
@@ -38,7 +38,7 @@ describe("Measure Group Observation", () => {
     mockFormikObj.errors = {};
     mockFormikObj.values = {};
     mockFormikObj.isSubmitting = false;
-    mockFormikObj.setFieldValue = undefined;
+    mockFormikObj.setFieldValue = jest.fn();
 
     const mockUuid = require("uuid") as { v4: jest.Mock<string, []> };
     mockUuid.v4.mockImplementationOnce(() => "uuid-1");
@@ -369,6 +369,8 @@ describe("Measure Group Observation", () => {
     // check if this value is already selected
     expect(observationInput.value).toBe("MyFunc1");
 
+    mockSetFieldValue.mockClear();
+
     fireEvent.change(observationInput, {
       target: { value: "MyFuncAB" },
     });
@@ -488,6 +490,8 @@ describe("Measure Group Observation", () => {
         linkMeasureObservationDisplay={true}
       />
     );
+
+    mockSetFieldValue.mockClear();
 
     const removeLink = screen.getByRole("link", { name: "Remove" });
     expect(removeLink).toBeInTheDocument();


### PR DESCRIPTION
… when a definition or reference is added to the grid, it will render its content with all the formatting that the user added intact

## MADiE PR

Jira Ticket: [MAT-8828](https://jira.cms.gov/browse/MAT-8828)
(Optional) Related Tickets:

### Summary

### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included.
* [ ] No extemporaneous files are included (i.e Complied files or testing results).
* [ ] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).
* [ ] All CDN/Web dependencies are hosted internally (i.e MADiE-Root Repo).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
