### PR TITLE
MAT-9050: Default empty text fields to empty string.

### DIFF
--- a/src/components/editMeasure/details/measureMetadata/MeasureMetadataHelper.ts
+++ b/src/components/editMeasure/details/measureMetadata/MeasureMetadataHelper.ts
@@ -14,8 +14,8 @@ export default function getInitialValues(measure: Measure, typeLower: string) {
       const copyright = measure?.measureMetaData?.copyright;
       return !!copyright ? copyright : "";
     case "disclaimer":
-      const diclaimer = measure?.measureMetaData?.disclaimer;
-      return !!diclaimer ? diclaimer : "";
+      const disclaimer = measure?.measureMetaData?.disclaimer;
+      return !!disclaimer ? disclaimer : "";
     case "rationale":
       const rationale = measure?.measureMetaData?.rationale;
       return !!rationale ? rationale : "";

--- a/src/components/editMeasure/populationCriteria/groups/QICore/QICoreMeasureGroups.test.tsx
+++ b/src/components/editMeasure/populationCriteria/groups/QICore/QICoreMeasureGroups.test.tsx
@@ -728,6 +728,7 @@ describe("Measure Groups Page", () => {
           associationType: undefined,
         },
       ],
+      rateAggregation: "",
       measureObservations: null,
       scoring: "Cohort",
       groupDescription: "",
@@ -736,6 +737,7 @@ describe("Measure Groups Page", () => {
       scoringUnit: "testScoringUnit",
       scoringPrecision: "2",
       improvementNotation: "Increased score indicates improvement",
+      improvementNotationDescription: "",
     };
 
     userEvent.click(screen.getByTestId("reporting-tab"));
@@ -956,6 +958,7 @@ describe("Measure Groups Page", () => {
       measureGroupTypes: ["Patient Reported Outcome"],
       rateAggregation: "",
       improvementNotation: "Increased score indicates improvement",
+      improvementNotationDescription: "",
       stratifications: [],
       populationBasis: populationBasis,
     };

--- a/src/components/editMeasure/populationCriteria/groups/QICore/QICoreMeasureGroups.tsx
+++ b/src/components/editMeasure/populationCriteria/groups/QICore/QICoreMeasureGroups.tsx
@@ -303,6 +303,7 @@ const MeasureGroups = (props: MeasureGroupProps) => {
     return pops.map((population) => {
       return {
         ...population,
+        description: population.description ? population.description : "",
         displayId: (
           population.name.replace(" ", "") +
           "_" +
@@ -341,6 +342,11 @@ const MeasureGroups = (props: MeasureGroupProps) => {
             measure?.groups[measureGroupNumber].measureObservations || null,
           improvementNotation:
             measure?.groups[measureGroupNumber].improvementNotation || "",
+          improvementNotationDescription:
+            measure?.groups[measureGroupNumber]
+              .improvementNotationDescription || "",
+          rateAggregation:
+            measure?.groups[measureGroupNumber].rateAggregation || "",
         },
       });
       setVisibleStrats(
@@ -361,6 +367,7 @@ const MeasureGroups = (props: MeasureGroupProps) => {
             stratifications: [getEmptyStrat(), getEmptyStrat()],
             rateAggregation: "",
             improvementNotation: "",
+            improvementNotationDescription: "",
             measureGroupTypes: [],
             populationBasis: defaultPopulationBasis,
             scoringUnit: "",

--- a/src/components/editMeasure/populationCriteria/groups/TextEditor.tsx
+++ b/src/components/editMeasure/populationCriteria/groups/TextEditor.tsx
@@ -43,7 +43,7 @@ const TextEditor = (props: Props) => {
       value === "<p></p>" || value === "<p><br></p>" ? "" : value;
     setFieldValue(field, normalized);
   }, 250);
-  // every 250 ms after an udpate to our local text, we update the formik value
+  // every 250 ms after an update to our local text, we update the formik value
   useEffect(() => {
     debounced(name, localText);
   }, [localText]);


### PR DESCRIPTION
## MADiE PR

Jira Ticket: [MAT-9050](https://jira.cms.gov/browse/MAT-9050)
(Optional) Related Tickets:

### Summary

The Rich Text Editor (RTE) outputs empty text as an empty HTML `p` tag (`<p></p>`).  To align with database values, this is normalized to an empty string (`""`). Due to inconsistent data management, some empty text fields are stored as empty string while other are `null`. This will initialize formik with empty string when the db value is null, matching the normalization of the RTE output. 

### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included.
* [ ] No extemporaneous files are included (i.e Complied files or testing results).
* [ ] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).
* [ ] All CDN/Web dependencies are hosted internally (i.e MADiE-Root Repo).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
