### PR TITLE
MAT-9021: Memoize group populations to default pop desc to empty string

### DIFF
--- a/src/components/editMeasure/populationCriteria/groups/QDM/QDMMeasureGroups.tsx
+++ b/src/components/editMeasure/populationCriteria/groups/QDM/QDMMeasureGroups.tsx
@@ -303,7 +303,10 @@ const MeasureGroups = (props: MeasureGroupProps) => {
       id: group?.id || null,
       scoring: measure?.scoring || "",
       populations: group?.populations
-        ? group.populations
+        ? group.populations.map((population) => ({
+            ...population,
+            description: population.description ?? "",
+          }))
         : getPopulationsForScoring(measure?.scoring),
       measureObservations: group?.measureObservations || memoizedObservation,
       rateAggregation: group?.rateAggregation || "",
@@ -346,11 +349,11 @@ const MeasureGroups = (props: MeasureGroupProps) => {
   });
   useFormikResetOnEvent(formik);
   const { resetForm, validateForm } = formik;
-  useEffect(() => {
-    if (measure?.groups && measure?.groups[measureGroupNumber]) {
-      validateForm();
-    }
-  }, [formik.values.populations, validateForm]);
+  // useEffect(() => {
+  //   if (measure?.groups && measure?.groups[measureGroupNumber]) {
+  //     validateForm();
+  //   }
+  // }, [formik.values.populations, validateForm]);
 
   useEffect(() => {
     const subscription = measureStore.subscribe((measure: Measure) => {

--- a/src/components/editMeasure/populationCriteria/groups/QDM/QDMMeasureGroups.tsx
+++ b/src/components/editMeasure/populationCriteria/groups/QDM/QDMMeasureGroups.tsx
@@ -298,16 +298,22 @@ const MeasureGroups = (props: MeasureGroupProps) => {
     return getDefaultObservationsForScoring(measure.scoring);
   }, [measure?.scoring]);
 
+  const getMemoizedPopulations = useMemo(() => {
+    if (!group?.populations) {
+      return getPopulationsForScoring(measure?.scoring);
+    }
+    const memoizedPopulations = group.populations.map((pop) => ({
+      ...pop,
+      description: pop.description ?? "",
+    }));
+    return memoizedPopulations;
+  }, [group?.populations]);
+
   const formik = useFormik({
     initialValues: {
       id: group?.id || null,
       scoring: measure?.scoring || "",
-      populations: group?.populations
-        ? group.populations.map((population) => ({
-            ...population,
-            description: population.description ?? "",
-          }))
-        : getPopulationsForScoring(measure?.scoring),
+      populations: getMemoizedPopulations, // must make stable variable to prevent extra renders.
       measureObservations: group?.measureObservations || memoizedObservation,
       rateAggregation: group?.rateAggregation || "",
       improvementNotation: group?.improvementNotation || "",
@@ -349,11 +355,11 @@ const MeasureGroups = (props: MeasureGroupProps) => {
   });
   useFormikResetOnEvent(formik);
   const { resetForm, validateForm } = formik;
-  // useEffect(() => {
-  //   if (measure?.groups && measure?.groups[measureGroupNumber]) {
-  //     validateForm();
-  //   }
-  // }, [formik.values.populations, validateForm]);
+  useEffect(() => {
+    if (measure?.groups && measure?.groups[measureGroupNumber]) {
+      validateForm();
+    }
+  }, [formik.values.populations, validateForm]);
 
   useEffect(() => {
     const subscription = measureStore.subscribe((measure: Measure) => {


### PR DESCRIPTION
## MADiE PR

Jira Ticket: [MAT-9021](https://jira.cms.gov/browse/MAT-9021)
(Optional) Related Tickets:

### Summary

Default empty population description to empty string since rich text editor assumes an empty field will be represented by an empty string.

### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included.
* [ ] No extemporaneous files are included (i.e Complied files or testing results).
* [ ] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).
* [ ] All CDN/Web dependencies are hosted internally (i.e MADiE-Root Repo).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
