### PR TITLE
MAT-8919: Prevent Deletion of Locked Test Cases

### DIFF
--- a/src/components/editMeasure/testCases/api/useTestCaseServiceApi.ts
+++ b/src/components/editMeasure/testCases/api/useTestCaseServiceApi.ts
@@ -156,23 +156,6 @@ export class TestCaseServiceApi {
     }
   }
 
-  async deleteTestCaseByTestCaseId(measureId: string, testCaseId: string) {
-    try {
-      const response = await axios.delete(
-        `${this.baseUrl}/measures/${measureId}/test-cases/${testCaseId}`,
-        {
-          headers: {
-            Authorization: `Bearer ${this.getAccessToken()}`,
-          },
-        }
-      );
-      return response.data;
-    } catch (err) {
-      const message = `Unable to delete test case`;
-      throw new Error(message);
-    }
-  }
-
   async deleteTestCases(measureId: string, testCaseIds: string[]) {
     return await axios.delete(
       `${this.baseUrl}/measures/${measureId}/test-cases`,

--- a/src/components/editMeasure/testCases/components/routes/qdm/TestCaseRoutes.tsx
+++ b/src/components/editMeasure/testCases/components/routes/qdm/TestCaseRoutes.tsx
@@ -3,7 +3,9 @@ import { Route, Routes } from "react-router-dom";
 import TestCaseLandingQdm from "../../testCaseLanding/qdm/TestCaseLanding";
 import EditTestCase from "../../editTestCase/qdm/EditTestCase";
 import NotFound from "../../notfound/NotFound";
-import StatusHandler from "../../statusHandler/StatusHandler";
+import StatusHandler, {
+  CustomWarningMessage,
+} from "../../statusHandler/StatusHandler";
 import { Measure, TestCaseImportOutcome } from "@madie/madie-models";
 import { measureStore } from "@madie/madie-util";
 import { CqmMeasure, ValueSet } from "cqm-models";
@@ -25,6 +27,12 @@ const TestCaseRoutes = () => {
   const [importWarnings, setImportWarnings] = useState<TestCaseImportOutcome[]>(
     []
   );
+  const [customWarningMessages, setCustomWarningMessages] = useState<
+    CustomWarningMessage[]
+  >([]);
+  const [shiftTestCaseDatesWarnings, setShiftTestCaseDatesWarnings] = useState<
+    Array<string>
+  >([]);
   const [importErrors, setImportErrors] = useState<Array<string>>([]);
   const [executionContextReady, setExecutionContextReady] =
     useState<boolean>(false);
@@ -191,10 +199,11 @@ const TestCaseRoutes = () => {
           testDataId="import-error-messages"
         />
       )}
-      {warnings?.length > 0 && (
+      {(warnings?.length || customWarningMessages?.length > 0) && (
         <StatusHandler
           warning={true}
-          shiftTestCaseDatesWarning={warnings}
+          shiftTestCaseDatesWarning={shiftTestCaseDatesWarnings}
+          customWarningMessages={customWarningMessages}
           testDataId="execution_context_loading_warning"
         />
       )}
@@ -219,6 +228,10 @@ const TestCaseRoutes = () => {
                     setWarnings={setWarnings}
                     setImportWarnings={setImportWarnings}
                     setImportErrors={setImportErrors}
+                    setShiftTestCaseDatesWarnings={
+                      setShiftTestCaseDatesWarnings
+                    }
+                    setCustomWarningMessages={setCustomWarningMessages}
                   />
                 }
               />
@@ -236,6 +249,10 @@ const TestCaseRoutes = () => {
                     setWarnings={setWarnings}
                     setImportWarnings={setImportWarnings}
                     setImportErrors={setImportErrors}
+                    setShiftTestCaseDatesWarnings={
+                      setShiftTestCaseDatesWarnings
+                    }
+                    setCustomWarningMessages={setCustomWarningMessages}
                   />
                 }
               />
@@ -282,6 +299,9 @@ const TestCaseRoutes = () => {
                     warnings={warnings}
                     setErrors={setErrors}
                     setImportWarnings={setImportWarnings}
+                    setShiftTestCaseDatesWarnings={
+                      setShiftTestCaseDatesWarnings
+                    }
                     setWarnings={setWarnings}
                   />
                 }

--- a/src/components/editMeasure/testCases/components/routes/qiCore/TestCaseRoutes.tsx
+++ b/src/components/editMeasure/testCases/components/routes/qiCore/TestCaseRoutes.tsx
@@ -9,7 +9,9 @@ import useTerminologyServiceApi from "../../../api/useTerminologyServiceApi";
 import { ExecutionContextProvider } from "./ExecutionContext";
 import useMeasureServiceApi from "../../../api/useMeasureServiceApi";
 import * as _ from "lodash";
-import StatusHandler from "../../statusHandler/StatusHandler";
+import StatusHandler, {
+  CustomWarningMessage,
+} from "../../statusHandler/StatusHandler";
 import TestCaseLandingWrapper from "../../testCaseLanding/common/TestCaseLandingWrapper";
 import {
   Measure,
@@ -29,6 +31,12 @@ const TestCaseRoutes = () => {
   const [valueSets, setValueSets] = useState<ValueSet[]>();
   const [errors, setErrors] = useState<Array<string>>([]);
   const [warnings, setWarnings] = useState<Array<string>>([]);
+  const [customWarningMessages, setCustomWarningMessages] = useState<
+    CustomWarningMessage[]
+  >([]);
+  const [shiftTestCaseDatesWarnings, setShiftTestCaseDatesWarnings] = useState<
+    Array<string>
+  >([]);
   const [importWarnings, setImportWarnings] = useState<TestCaseImportOutcome[]>(
     []
   );
@@ -140,11 +148,13 @@ const TestCaseRoutes = () => {
           testDataId="execution_context_loading_errors"
         />
       )}
-      {warnings?.length > 0 && (
+      {(warnings?.length || customWarningMessages?.length > 0) && (
         <>
           <StatusHandler
             warning={true}
-            shiftTestCaseDatesWarning={warnings}
+            warningMessages={warnings}
+            customWarningMessages={customWarningMessages}
+            shiftTestCaseDatesWarning={shiftTestCaseDatesWarnings}
             testDataId="execution_context_loading_warning"
           />
         </>
@@ -166,6 +176,10 @@ const TestCaseRoutes = () => {
                     setErrors={setErrors}
                     setImportWarnings={setImportWarnings}
                     setWarnings={setWarnings}
+                    setShiftTestCaseDatesWarnings={
+                      setShiftTestCaseDatesWarnings
+                    }
+                    setCustomWarningMessages={setCustomWarningMessages}
                   />
                 }
               />
@@ -183,6 +197,10 @@ const TestCaseRoutes = () => {
                     setErrors={setErrors}
                     setImportWarnings={setImportWarnings}
                     setWarnings={setWarnings}
+                    setShiftTestCaseDatesWarnings={
+                      setShiftTestCaseDatesWarnings
+                    }
+                    setCustomWarningMessages={setCustomWarningMessages}
                   />
                 }
               />
@@ -233,6 +251,9 @@ const TestCaseRoutes = () => {
                     warnings={warnings}
                     setErrors={setErrors}
                     setImportWarnings={setImportWarnings}
+                    setShiftTestCaseDatesWarnings={
+                      setShiftTestCaseDatesWarnings
+                    }
                     setWarnings={setWarnings}
                   />
                 }

--- a/src/components/editMeasure/testCases/components/statusHandler/StatusHandler.test.tsx
+++ b/src/components/editMeasure/testCases/components/statusHandler/StatusHandler.test.tsx
@@ -362,4 +362,51 @@ describe("StatusHandler Component", () => {
       expect.anything()
     );
   });
+
+  test("Should display warning and customWarningMessages with correct configuration", () => {
+    const customWarningMessages = [
+      {
+        message: "Custom Warning 1:",
+        details: ["Detail 1", "Detail 2"],
+      },
+      {
+        message: "Custom Warning 2:",
+        details: ["Detail A"],
+      },
+    ];
+
+    render(
+      <StatusHandler
+        warning={true}
+        customWarningMessages={customWarningMessages}
+        testDataId="test_data_id"
+      />
+    );
+
+    expect(screen.getByTestId("madie-alert-mock")).toBeInTheDocument();
+    expect(screen.getByTestId("alert-0")).toHaveAttribute(
+      "data-type",
+      "warning"
+    );
+    expect(screen.getByTestId("alert-1")).toHaveAttribute(
+      "data-type",
+      "warning"
+    );
+    expect(screen.getByText("Custom Warning 1:")).toBeInTheDocument();
+    expect(screen.getByText("Detail 1")).toBeInTheDocument();
+    expect(screen.getByText("Detail 2")).toBeInTheDocument();
+
+    expect(MadieAlert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        alerts: expect.arrayContaining([
+          expect.objectContaining({
+            type: "warning",
+            copyButton: true,
+            canClose: false,
+          }),
+        ]),
+      }),
+      expect.anything()
+    );
+  });
 });

--- a/src/components/editMeasure/testCases/components/statusHandler/StatusHandler.tsx
+++ b/src/components/editMeasure/testCases/components/statusHandler/StatusHandler.tsx
@@ -105,6 +105,7 @@ const StatusHandler = ({
     }
   }
 
+  // TODO: Replace scenario specific warning path with generic customWarningMessages
   if (warning && shiftTestCaseDatesWarning) {
     const withoutDuplicates = [...new Set(shiftTestCaseDatesWarning)];
     if (withoutDuplicates.length > 0) {

--- a/src/components/editMeasure/testCases/components/statusHandler/StatusHandler.tsx
+++ b/src/components/editMeasure/testCases/components/statusHandler/StatusHandler.tsx
@@ -13,11 +13,18 @@ import {
   createWarningMessage,
 } from "./StatusHandlerMessage";
 
+export interface CustomWarningMessage {
+  message: string;
+  details?: string[];
+  testDataId?: string;
+}
+
 interface StatusHandlerProps {
   error?: boolean;
   warning?: boolean;
   errorMessages?: Array<string>;
   warningMessages?: Array<string>;
+  customWarningMessages?: CustomWarningMessage[];
   testDataId?: string;
   importWarnings?: TestCaseImportOutcome[];
   shiftTestCaseDatesWarning?: Array<string>;
@@ -33,6 +40,7 @@ const StatusHandler = ({
   importWarnings,
   shiftTestCaseDatesWarning,
   missingDataElements,
+  customWarningMessages,
 }: StatusHandlerProps) => {
   const alerts = [];
 
@@ -111,6 +119,14 @@ const StatusHandler = ({
     if (withoutDuplicates.length > 0) {
       alerts.push(createWarningMessage(withoutDuplicates, testDataId));
     }
+  }
+
+  if (warning && customWarningMessages) {
+    customWarningMessages.forEach((cwm) => {
+      alerts.push(
+        createWarningMessage([...new Set(cwm.details)], testDataId, cwm.message)
+      );
+    });
   }
 
   if (importWarnings && importWarnings.length > 0) {

--- a/src/components/editMeasure/testCases/components/statusHandler/StatusHandlerMessage.test.tsx
+++ b/src/components/editMeasure/testCases/components/statusHandler/StatusHandlerMessage.test.tsx
@@ -175,4 +175,20 @@ describe("StatusHandler Messages", () => {
     expect(multipleListItems[1]).toHaveTextContent("Data Element 2");
     expect(multipleListItems[2]).toHaveTextContent("Data Element 3");
   });
+  it("Should handle createWarningMessage when message is not provided", () => {
+    const warnings = ["Warning 1", "Warning 2"];
+    const config = createWarningMessage(warnings, "no-message-warning-test-id");
+
+    expect(config.type).toBe("warning");
+    expect(config.copyButton).toBe(true);
+    expect(config.canClose).toBe(false);
+    expect(config.alertProps).toEqual({
+      "data-testid": "no-message-warning-test-id",
+    });
+
+    const { getByTestId } = render(<div>{config.content}</div>);
+    const warnTitle = getByTestId("warn-title");
+
+    expect(warnTitle).toBeInTheDocument();
+  });
 });

--- a/src/components/editMeasure/testCases/components/statusHandler/StatusHandlerMessage.tsx
+++ b/src/components/editMeasure/testCases/components/statusHandler/StatusHandlerMessage.tsx
@@ -3,6 +3,7 @@ import { TestCaseImportOutcome } from "@madie/madie-models";
 import "twin.macro";
 import "styled-components/macro";
 
+// TODO: Remove and use createWarningMessage with custom message instead.
 export function createShiftTestCaseDatesWarningMessage(
   withoutDuplicates: string[],
   testDataId: string

--- a/src/components/editMeasure/testCases/components/statusHandler/StatusHandlerMessage.tsx
+++ b/src/components/editMeasure/testCases/components/statusHandler/StatusHandlerMessage.tsx
@@ -30,7 +30,8 @@ export function createShiftTestCaseDatesWarningMessage(
 
 export function createWarningMessage(
   withoutDuplicates: string[],
-  testDataId: string
+  testDataId: string,
+  message?: string
 ) {
   return {
     type: "warning",
@@ -38,6 +39,7 @@ export function createWarningMessage(
     content: (
       <div aria-live="polite" role="alert" data-testid={testDataId}>
         <div data-testid="warn-title">
+          {message ? message + " " : ""}
           {withoutDuplicates.length === 1 ? (
             withoutDuplicates[0]
           ) : (

--- a/src/components/editMeasure/testCases/components/testCaseLanding/common/TestCaseTable/TestCaseTable.tsx
+++ b/src/components/editMeasure/testCases/components/testCaseLanding/common/TestCaseTable/TestCaseTable.tsx
@@ -50,6 +50,7 @@ interface TestCaseTableProps {
   setShiftDatesDialogModalOpen: any;
   setWarnings: any;
   page: number;
+  setShiftTestCaseDatesWarnings: any;
 }
 
 const fiberManualRecordStyles = {
@@ -121,7 +122,7 @@ const TestCaseTable = (props: TestCaseTableProps) => {
     setDeleteDialogModalOpen,
     shiftDatesDialogModalOpen,
     setShiftDatesDialogModalOpen,
-    setWarnings,
+    setShiftTestCaseDatesWarnings,
   } = props;
   const viewOrEdit = canEdit ? "edit" : "view";
   const [toastOpen, setToastOpen] = useState<boolean>(false);
@@ -544,7 +545,7 @@ const TestCaseTable = (props: TestCaseTableProps) => {
           canEdit={canEdit}
           testCases={selectedTestCases ? selectedTestCases : []}
           measure={measure}
-          setWarnings={setWarnings}
+          setShiftTestCaseDatesWarnings={setShiftTestCaseDatesWarnings}
           setToastOpen={setToastOpen}
           setToastType={setToastType}
           setToastMessage={setToastMessage}

--- a/src/components/editMeasure/testCases/components/testCaseLanding/common/interfaces.tsx
+++ b/src/components/editMeasure/testCases/components/testCaseLanding/common/interfaces.tsx
@@ -1,5 +1,6 @@
 import React, { Dispatch, SetStateAction } from "react";
 import { TestCaseImportOutcome } from "@madie/madie-models";
+import { CustomWarningMessage } from "../../statusHandler/StatusHandler";
 
 export interface TestCasesPassingDetailsProps {
   passPercentage: number;
@@ -13,4 +14,6 @@ export interface TestCaseListProps {
   setImportErrors?: Dispatch<SetStateAction<Array<string>>>;
   setWarnings?: Dispatch<SetStateAction<Array<string>>>;
   setImportWarnings?: Dispatch<SetStateAction<TestCaseImportOutcome[]>>;
+  setShiftTestCaseDatesWarnings?: Dispatch<SetStateAction<Array<string>>>;
+  setCustomWarningMessages?: Dispatch<SetStateAction<CustomWarningMessage[]>>;
 }

--- a/src/components/editMeasure/testCases/components/testCaseLanding/common/shiftDates/ShiftDatesDialog.test.tsx
+++ b/src/components/editMeasure/testCases/components/testCaseLanding/common/shiftDates/ShiftDatesDialog.test.tsx
@@ -159,7 +159,7 @@ describe("Shift Test Case Dates Dialog", () => {
     const setToastOpen = jest.fn();
     const setToastType = jest.fn();
     const setToastMessage = jest.fn();
-    const setWarnings = jest.fn();
+    const setShiftTestCaseDatesWarnings = jest.fn();
     await act(async () => {
       const { findByTestId, queryByTestId } = render(
         <ShiftDatesDialog
@@ -168,7 +168,7 @@ describe("Shift Test Case Dates Dialog", () => {
           canEdit={true}
           testCases={testCases}
           measure={measure}
-          setWarnings={setWarnings}
+          setShiftTestCaseDatesWarnings={setShiftTestCaseDatesWarnings}
           setToastOpen={setToastOpen}
           setToastType={setToastType}
           setToastMessage={setToastMessage}
@@ -199,7 +199,7 @@ describe("Shift Test Case Dates Dialog", () => {
         expect(setToastMessage).not.toBeCalledWith(
           `All Test Case dates successfully shifted.`
         );
-        expect(setWarnings).toBeCalledTimes(1);
+        expect(setShiftTestCaseDatesWarnings).toBeCalledTimes(1);
       });
     });
   });
@@ -336,7 +336,7 @@ describe("Shift Test Case Dates Dialog", () => {
     const setToastOpen = jest.fn();
     const setToastType = jest.fn();
     const setToastMessage = jest.fn();
-    const setWarnings = jest.fn();
+    const setShiftTestCaseDatesWarnings = jest.fn();
     await act(async () => {
       const { findByTestId } = render(
         <ShiftDatesDialog
@@ -345,7 +345,7 @@ describe("Shift Test Case Dates Dialog", () => {
           canEdit={true}
           testCases={testCases}
           measure={qiCoreMeasure}
-          setWarnings={setWarnings}
+          setShiftTestCaseDatesWarnings={setShiftTestCaseDatesWarnings}
           setToastOpen={setToastOpen}
           setToastType={setToastType}
           setToastMessage={setToastMessage}
@@ -376,7 +376,7 @@ describe("Shift Test Case Dates Dialog", () => {
         expect(setToastMessage).not.toBeCalledWith(
           `All Test Case dates successfully shifted.`
         );
-        expect(setWarnings).toBeCalledTimes(1);
+        expect(setShiftTestCaseDatesWarnings).toBeCalledTimes(1);
       });
     });
   });

--- a/src/components/editMeasure/testCases/components/testCaseLanding/common/shiftDates/ShiftDatesDialog.tsx
+++ b/src/components/editMeasure/testCases/components/testCaseLanding/common/shiftDates/ShiftDatesDialog.tsx
@@ -16,10 +16,10 @@ interface shiftDatesDialogProps {
   canEdit?: boolean;
   testCases?: TestCase[];
   measure: Measure;
-  setWarnings: Function;
   setToastOpen: Function;
   setToastType: Function;
   setToastMessage: Function;
+  setShiftTestCaseDatesWarnings: Function;
 }
 
 const ShiftDatesDialog = ({
@@ -28,10 +28,10 @@ const ShiftDatesDialog = ({
   canEdit,
   testCases,
   measure,
-  setWarnings,
   setToastOpen,
   setToastType,
   setToastMessage,
+  setShiftTestCaseDatesWarnings,
 }: shiftDatesDialogProps) => {
   const featureFlags = useFeatureFlags();
   const testCaseService = useRef(useTestCaseServiceApi());
@@ -60,7 +60,10 @@ const ShiftDatesDialog = ({
             setToastType("success");
             setToastMessage(`All Test Case dates successfully shifted.`);
           } else {
-            setWarnings((prevState) => [...prevState, ...response]);
+            setShiftTestCaseDatesWarnings((prevState) => [
+              ...prevState,
+              ...response,
+            ]);
           }
         })
         .catch((err) => {
@@ -81,7 +84,10 @@ const ShiftDatesDialog = ({
             setToastType("success");
             setToastMessage(`All Test Case dates successfully shifted.`);
           } else {
-            setWarnings((prevState) => [...prevState, ...response]);
+            setShiftTestCaseDatesWarnings((prevState) => [
+              ...prevState,
+              ...response,
+            ]);
           }
         })
         .catch((err) => {

--- a/src/components/editMeasure/testCases/components/testCaseLanding/qdm/CreateCodeCoverageNavTabs.tsx
+++ b/src/components/editMeasure/testCases/components/testCaseLanding/qdm/CreateCodeCoverageNavTabs.tsx
@@ -34,7 +34,6 @@ export interface NavTabProps {
   coveragePercentage: string;
   validTestCases: TestCase[];
   selectedPopCriteria: Group;
-  onDeleteAllTestCases: () => void;
   onExportQRDA: () => void;
   onExportExcel: (fileType: string) => void;
   exportExecuting: boolean;
@@ -59,7 +58,6 @@ const defaultStyle = {
 
 export default function CreateCodeCoverageNavTabs(props: NavTabProps) {
   const { executionContextReady, contextFailure } = useQdmExecutionContext();
-  const exportMessage = "Test cases must be executed prior to exporting.";
   const {
     activeTab,
     setActiveTab,
@@ -71,11 +69,8 @@ export default function CreateCodeCoverageNavTabs(props: NavTabProps) {
     testCasePassFailStats,
     coveragePercentage,
     validTestCases,
-    selectedPopCriteria,
-    onDeleteAllTestCases,
     onExportQRDA,
     onExportExcel,
-    exportExecuting,
     optionsOpen,
     setOptionsOpen,
     onGenerateOverlappingCodesReport,

--- a/src/components/editMeasure/testCases/components/testCaseLanding/qdm/TestCaseLanding.tsx
+++ b/src/components/editMeasure/testCases/components/testCaseLanding/qdm/TestCaseLanding.tsx
@@ -17,6 +17,8 @@ const TestCaseLandingQdm = (props: TestCaseListProps) => {
           setWarnings={props.setWarnings}
           setImportErrors={props.setImportErrors}
           setImportWarnings={props.setImportWarnings}
+          setCustomWarningMessages={props.setCustomWarningMessages}
+          setShiftTestCaseDatesWarnings={props.setShiftTestCaseDatesWarnings}
         />
       </section>
     </div>

--- a/src/components/editMeasure/testCases/components/testCaseLanding/qdm/TestCaseList.test.tsx
+++ b/src/components/editMeasure/testCases/components/testCaseLanding/qdm/TestCaseList.test.tsx
@@ -1547,12 +1547,12 @@ describe("TestCaseList component", () => {
     });
   });
 
-  it("Should handle delete error, when a 409 error is returned from the server", async () => {
+  it("Should handle delete error, when a 423 error is returned from the server", async () => {
     useTestCaseServiceMock.mockImplementation(() => {
       return {
         ...useTestCaseServiceMockResolved,
         deleteTestCases: jest.fn().mockRejectedValue({
-          response: { status: 409, data: { message: "1234,4321" } },
+          response: { status: 423, data: { message: "1234,4321" } },
         }),
       } as unknown as TestCaseServiceApi;
     });
@@ -1593,12 +1593,12 @@ describe("TestCaseList component", () => {
     });
   });
 
-  it("Should handle delete error of 409, when all selected test cases are in use by another user", async () => {
+  it("Should handle delete error of 423, when all selected test cases are in use by another user", async () => {
     useTestCaseServiceMock.mockImplementation(() => {
       return {
         ...useTestCaseServiceMockResolved,
         deleteTestCases: jest.fn().mockRejectedValue({
-          response: { status: 409, data: { message: "4321" } },
+          response: { status: 423, data: { message: "4321" } },
         }),
       } as unknown as TestCaseServiceApi;
     });

--- a/src/components/editMeasure/testCases/components/testCaseLanding/qdm/TestCaseList.test.tsx
+++ b/src/components/editMeasure/testCases/components/testCaseLanding/qdm/TestCaseList.test.tsx
@@ -58,6 +58,8 @@ import useQdmCqlParsingService, {
 } from "../../../api/cqlElmTranslationService/useQdmCqlParsingService";
 import TestCaseLandingWrapper from "../common/TestCaseLandingWrapper";
 import TestCaseLanding from "../qdm/TestCaseLanding";
+import { set } from "lodash";
+import { wait } from "@testing-library/user-event/dist/utils";
 
 const serviceConfig = {
   qdmElmTranslationService: { baseUrl: "translator.url" },
@@ -1276,7 +1278,7 @@ const setCqmMeasure = jest.fn();
 const setError = jest.fn();
 const setWarnings = jest.fn();
 const setImportErrors = jest.fn();
-
+const setCustomWarningMessage = jest.fn();
 window.URL.createObjectURL = jest.fn().mockImplementation(() => "url");
 
 describe("TestCaseList component", () => {
@@ -1316,7 +1318,8 @@ describe("TestCaseList component", () => {
   function renderTestCaseListComponent(
     mockError = setError,
     errors: string[] = [],
-    contextFailure = false
+    contextFailure = false,
+    setCustomWarningMessages = setCustomWarningMessage
   ) {
     return render(
       <MemoryRouter
@@ -1349,6 +1352,7 @@ describe("TestCaseList component", () => {
                           setErrors={mockError}
                           setWarnings={setWarnings}
                           setImportErrors={setImportErrors}
+                          setCustomWarningMessages={setCustomWarningMessages}
                         />
                       }
                     />
@@ -1365,6 +1369,7 @@ describe("TestCaseList component", () => {
                           setErrors={mockError}
                           setWarnings={setWarnings}
                           setImportErrors={setImportErrors}
+                          setCustomWarningMessages={setCustomWarningMessages}
                         />
                       }
                     />
@@ -1538,6 +1543,93 @@ describe("TestCaseList component", () => {
     await waitFor(() => {
       expect(screen.getByTestId("test-case-list-error")).toHaveTextContent(
         `Unable to Delete test Case(s) with ID(s) ${testCases[2].id}. Please try again. If the issue continues, please contact helpdesk.`
+      );
+    });
+  });
+
+  it("Should handle delete error, when a 409 error is returned from the server", async () => {
+    useTestCaseServiceMock.mockImplementation(() => {
+      return {
+        ...useTestCaseServiceMockResolved,
+        deleteTestCases: jest.fn().mockRejectedValue({
+          response: { status: 409, data: { message: "1234,4321" } },
+        }),
+      } as unknown as TestCaseServiceApi;
+    });
+
+    renderTestCaseListComponent();
+    await waitFor(() => {
+      const selectButton = screen.getByTestId(`test-case-title-0_select`);
+      const checkboxButton = within(selectButton).getByRole("checkbox");
+      expect(checkboxButton).toBeInTheDocument();
+      fireEvent.click(checkboxButton);
+      expect(checkboxButton).toBeChecked();
+    });
+
+    const deleteButton = screen.getByTestId("delete-action-icon");
+    expect(deleteButton).toBeEnabled();
+    fireEvent.click(deleteButton);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("delete-dialog")).toBeInTheDocument();
+    });
+    const confirmDeleteBtn = screen.getByRole("button", {
+      name: "Yes, Delete",
+    });
+    expect(
+      screen.getByTestId("delete-dialog-cancel-button")
+    ).toBeInTheDocument();
+
+    userEvent.click(confirmDeleteBtn);
+    await waitFor(() => {
+      expect(setCustomWarningMessage).toHaveBeenCalledWith([
+        {
+          message:
+            "Some of the selected test cases were deleted successfully, but the following test cases are in-use by another user and could not be deleted:",
+          details: ["1234", "4321"],
+          testDataId: "test-cases-in-use-warning",
+        },
+      ]);
+    });
+  });
+
+  it("Should handle delete error of 409, when all selected test cases are in use by another user", async () => {
+    useTestCaseServiceMock.mockImplementation(() => {
+      return {
+        ...useTestCaseServiceMockResolved,
+        deleteTestCases: jest.fn().mockRejectedValue({
+          response: { status: 409, data: { message: "4321" } },
+        }),
+      } as unknown as TestCaseServiceApi;
+    });
+
+    renderTestCaseListComponent();
+    await waitFor(() => {
+      const selectButton = screen.getByTestId(`test-case-title-0_select`);
+      const checkboxButton = within(selectButton).getByRole("checkbox");
+      expect(checkboxButton).toBeInTheDocument();
+      fireEvent.click(checkboxButton);
+      expect(checkboxButton).toBeChecked();
+    });
+
+    const deleteButton = screen.getByTestId("delete-action-icon");
+    expect(deleteButton).toBeEnabled();
+    fireEvent.click(deleteButton);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("delete-dialog")).toBeInTheDocument();
+    });
+    const confirmDeleteBtn = screen.getByRole("button", {
+      name: "Yes, Delete",
+    });
+    expect(
+      screen.getByTestId("delete-dialog-cancel-button")
+    ).toBeInTheDocument();
+
+    userEvent.click(confirmDeleteBtn);
+    await waitFor(() => {
+      expect(screen.getByTestId("test-case-list-success")).toHaveTextContent(
+        `All the selected test cases are in-use by another user and could not be deleted.`
       );
     });
   });
@@ -2752,6 +2844,42 @@ describe("TestCaseList component", () => {
       expect(toastMessage).toHaveTextContent("Test cases successfully deleted");
       expect(screen.queryByTestId("delete-dialog-body")).toBeNull();
     }, 15000);
+  });
+
+  it("Should handle delete all test case error message with Unable to dlete all test cases", async () => {
+    useTestCaseServiceMock.mockImplementation(() => {
+      return {
+        ...useTestCaseServiceMockResolved,
+        deleteTestCases: jest
+          .fn()
+          .mockRejectedValueOnce(new Error("Unable to delete all test cases.")),
+      } as unknown as TestCaseServiceApi;
+    });
+    renderTestCaseListComponent();
+    await waitFor(() => {
+      const table = screen.getByTestId("test-case-tbl");
+    });
+    const checkboxes = screen.getAllByRole("checkbox");
+    userEvent.click(checkboxes[1]);
+    userEvent.click(checkboxes[2]);
+
+    const deleteButton = screen.getByTestId("delete-action-btn");
+    expect(deleteButton).toBeInTheDocument();
+    userEvent.click(deleteButton);
+    const deleteDialog = screen.getByTestId("delete-dialog");
+    expect(deleteDialog).toBeInTheDocument();
+    const confirmDelete = screen.getByTestId("delete-dialog-continue-button");
+    expect(confirmDelete).toBeInTheDocument();
+    expect(
+      screen.getByTestId("delete-dialog-cancel-button")
+    ).toBeInTheDocument();
+    userEvent.click(confirmDelete);
+
+    const toastMessage = await screen.findByTestId("test-case-list-error");
+    expect(toastMessage).toHaveTextContent(
+      "Unable to Delete test Case(s) with ID(s) 3, 2. Please try again. If the issue continues, please contact helpdesk."
+    );
+    expect(screen.queryByTestId("delete-dialog-body")).toBeNull();
   });
 
   it("Should display test case copy dialog when at least one test case is selected", async () => {

--- a/src/components/editMeasure/testCases/components/testCaseLanding/qdm/TestCaseList.tsx
+++ b/src/components/editMeasure/testCases/components/testCaseLanding/qdm/TestCaseList.tsx
@@ -384,7 +384,7 @@ const TestCaseList = (props: TestCaseListProps) => {
       })
       .catch((err) => {
         console.error("deleteTestCases: err.message = " + err.message);
-        if (err?.response?.status == 409) {
+        if (err?.response?.status == 423) {
           if (
             testCaseIds.length ===
             err?.response?.data?.message?.split(",").length

--- a/src/components/editMeasure/testCases/components/testCaseLanding/qdm/TestCaseList.tsx
+++ b/src/components/editMeasure/testCases/components/testCaseLanding/qdm/TestCaseList.tsx
@@ -18,7 +18,6 @@ import { checkUserCanEdit } from "@madie/madie-util";
 import CreateCodeCoverageNavTabs from "./CreateCodeCoverageNavTabs";
 import CreateNewTestCaseDialog from "../../createTestCase/CreateNewTestCaseDialog";
 import {
-  MadieDeleteDialog,
   MadieSpinner,
   Pagination,
   Toast,
@@ -154,8 +153,6 @@ const TestCaseList = (props: TestCaseListProps) => {
   const [executeAllTestCases, setExecuteAllTestCases] =
     useState<boolean>(false);
   const [coveragePercentage, setCoveragePercentage] = useState<string>("-");
-  const [openDeleteAllTestCasesDialog, setOpenDeleteAllTestCasesDialog] =
-    useState<boolean>(false);
   const [testCasePassFailStats, setTestCasePassFailStats] =
     useState<TestCasesPassingDetailsProps>({
       passPercentage: undefined,
@@ -510,27 +507,6 @@ const TestCaseList = (props: TestCaseListProps) => {
     ? Object.keys(calculationOutput).length
     : 0;
 
-  const deleteAllTestCases = () => {
-    const currentTestCaseIds = _.map(measure.testCases, "id");
-    testCaseService.current
-      .deleteTestCases(measureId, currentTestCaseIds)
-      .then(() => {
-        retrieveTestCases();
-        setOpenDeleteAllTestCasesDialog(false);
-        setToastOpen(true);
-        setToastType("success");
-        setToastMessage("Test cases successfully deleted");
-      })
-      .catch(() => {
-        setOpenDeleteAllTestCasesDialog(false);
-        setToastOpen(true);
-        setToastType("danger");
-        setToastMessage(
-          "Unable to Delete All test Cases. Please try again. If the issue continues, please contact helpdesk."
-        );
-      });
-  };
-
   const exportExcel = async () => {
     if (measure?.cql) {
       setExportExecuting(true);
@@ -731,9 +707,6 @@ const TestCaseList = (props: TestCaseListProps) => {
                 coveragePercentage={coveragePercentage}
                 validTestCases={testCases?.filter((tc) => tc.validResource)}
                 selectedPopCriteria={selectedPopCriteria}
-                onDeleteAllTestCases={() =>
-                  setOpenDeleteAllTestCasesDialog(true)
-                }
                 onExportQRDA={exportQRDA}
                 onExportExcel={exportExcel}
                 exportExecuting={exportExecuting}
@@ -873,17 +846,6 @@ const TestCaseList = (props: TestCaseListProps) => {
           <Typography color="inherit">{loadingState.message}</Typography>
         </div>
       )}
-      <MadieDeleteDialog
-        open={openDeleteAllTestCasesDialog}
-        onContinue={() => {
-          deleteAllTestCases();
-        }}
-        onClose={() => {
-          setOpenDeleteAllTestCasesDialog(false);
-        }}
-        dialogTitle="Delete All Test Cases"
-        name="All Test Cases"
-      />
       <CopyTestCaseDialog
         selectedTestCases={selectedTestCases}
         open={openCopyTestCaseDialog}

--- a/src/components/editMeasure/testCases/components/testCaseLanding/qdm/TestCaseList.tsx
+++ b/src/components/editMeasure/testCases/components/testCaseLanding/qdm/TestCaseList.tsx
@@ -94,7 +94,14 @@ const TestCaseList = (props: TestCaseListProps) => {
   let navigate = useNavigate();
   const { search } = useLocation();
   const values = queryString.parse(search);
-  const { setErrors, setImportErrors, setWarnings, setImportWarnings } = props;
+  const {
+    setErrors,
+    setImportErrors,
+    setWarnings,
+    setImportWarnings,
+    setCustomWarningMessages,
+    setShiftTestCaseDatesWarnings,
+  } = props;
   const { measureId, criteriaId } = useParams<{
     measureId: string;
     criteriaId: string;
@@ -778,6 +785,9 @@ const TestCaseList = (props: TestCaseListProps) => {
                         shiftDatesDialogModalOpen={shiftDatesDialogModalOpen}
                         setShiftDatesDialogModalOpen={
                           setShiftDatesDialogModalOpen
+                        }
+                        setShiftTestCaseDatesWarnings={
+                          setShiftTestCaseDatesWarnings
                         }
                         setWarnings={setWarnings}
                         page={page}

--- a/src/components/editMeasure/testCases/components/testCaseLanding/qdm/TestCaseList.tsx
+++ b/src/components/editMeasure/testCases/components/testCaseLanding/qdm/TestCaseList.tsx
@@ -368,25 +368,7 @@ const TestCaseList = (props: TestCaseListProps) => {
     setExecuteAllTestCases(false);
   };
 
-  const deleteTestCase = (testCaseId) => {
-    testCaseService.current
-      .deleteTestCaseByTestCaseId(measureId, testCaseId)
-      .then(() => {
-        retrieveTestCases();
-      })
-      .catch((err) => {
-        console.error(
-          "deleteTestCaseByTestCaseId: err.message = " + err.message
-        );
-        setToastOpen(true);
-        setToastType("danger");
-        setToastMessage(
-          `Unable to Delete test Case with ID ${testCaseId}. Please try again. If the issue continues, please contact helpdesk.`
-        );
-      });
-  };
-
-  const deleteMultipleTestCases = () => {
+  const deleteTestCases = () => {
     const testCaseIds = selectedTestCases?.map((testCase) => testCase.id);
     testCaseService.current
       .deleteTestCases(measureId, testCaseIds)
@@ -785,7 +767,7 @@ const TestCaseList = (props: TestCaseListProps) => {
                         setSorting={setSorting}
                         testCases={currentSlice}
                         canEdit={canEdit}
-                        deleteTestCase={deleteMultipleTestCases}
+                        deleteTestCase={deleteTestCases}
                         exportTestCase={null}
                         onCloneTestCase={handleCloneTestCase}
                         measure={measure}

--- a/src/components/editMeasure/testCases/components/testCaseLanding/qdm/TestCaseList.tsx
+++ b/src/components/editMeasure/testCases/components/testCaseLanding/qdm/TestCaseList.tsx
@@ -387,13 +387,36 @@ const TestCaseList = (props: TestCaseListProps) => {
       })
       .catch((err) => {
         console.error("deleteTestCases: err.message = " + err.message);
-        setToastOpen(true);
-        setToastType("danger");
-        setToastMessage(
-          `Unable to Delete test Case(s) with ID(s) ${testCaseIds.join(
-            ", "
-          )}. Please try again. If the issue continues, please contact helpdesk.`
-        );
+        if (err?.response?.status == 409) {
+          if (
+            testCaseIds.length ===
+            err?.response?.data?.message?.split(",").length
+          ) {
+            setToastMessage(
+              "All the selected test cases are in-use by another user and could not be deleted."
+            );
+            setToastOpen(true);
+            setToastType("warning");
+          } else {
+            retrieveTestCases();
+            setCustomWarningMessages([
+              {
+                message:
+                  "Some of the selected test cases were deleted successfully, but the following test cases are in-use by another user and could not be deleted:",
+                details: err?.response?.data?.message?.split(","),
+                testDataId: "test-cases-in-use-warning",
+              },
+            ]);
+          }
+        } else {
+          setToastOpen(true);
+          setToastType("danger");
+          setToastMessage(
+            `Unable to Delete test Case(s) with ID(s) ${testCaseIds.join(
+              ", "
+            )}. Please try again. If the issue continues, please contact helpdesk.`
+          );
+        }
       });
   };
 

--- a/src/components/editMeasure/testCases/components/testCaseLanding/qiCore/TestCaseLanding.tsx
+++ b/src/components/editMeasure/testCases/components/testCaseLanding/qiCore/TestCaseLanding.tsx
@@ -16,6 +16,8 @@ const TestCaseLanding = (props: TestCaseListProps) => {
           setErrors={props.setErrors}
           setWarnings={props.setWarnings}
           setImportWarnings={props.setImportWarnings}
+          setShiftTestCaseDatesWarnings={props.setShiftTestCaseDatesWarnings}
+          setCustomWarningMessages={props.setCustomWarningMessages}
         />
       </section>
     </div>

--- a/src/components/editMeasure/testCases/components/testCaseLanding/qiCore/TestCaseList.test.tsx
+++ b/src/components/editMeasure/testCases/components/testCaseLanding/qiCore/TestCaseList.test.tsx
@@ -500,6 +500,7 @@ const setMeasureBundle = jest.fn();
 const setValueSets = jest.fn();
 const setError = jest.fn();
 const setWarnings = jest.fn();
+const setCustomWarningMessages = jest.fn();
 const setImportWarnings = jest.fn();
 
 // Test Case import related
@@ -612,6 +613,7 @@ describe("TestCaseList component", () => {
                           setErrors={setError}
                           setWarnings={setWarnings}
                           setImportWarnings={setImportWarnings}
+                          setCustomWarningMessages={setCustomWarningMessages}
                         />
                       }
                     />
@@ -815,6 +817,49 @@ describe("TestCaseList component", () => {
     userEvent.click(confirmDeleteBtn);
     await waitFor(() => expect(setError).toHaveBeenCalled());
     expect(nextState).toEqual(["BAD THINGS"]);
+  });
+
+  it("should handle response list of locked test cases on Test Case list page when delete button is clicked", async () => {
+    useTestCaseServiceMock.mockImplementation(() => {
+      return {
+        ...useTestCaseServiceMockResolved,
+        deleteTestCases: jest.fn().mockRejectedValue({
+          response: {
+            status: 409,
+            data: {
+              message: "ID1,ID2",
+            },
+          },
+        }),
+      } as unknown as TestCaseServiceApi;
+    });
+
+    renderTestCaseListComponent();
+    await waitFor(() => {
+      const selectButton = screen.getByTestId(`test-case-title-0_select`);
+      const checkboxButton = within(selectButton).getByRole("checkbox");
+      expect(checkboxButton).toBeInTheDocument();
+      fireEvent.click(checkboxButton);
+      expect(checkboxButton).toBeChecked();
+    });
+
+    const deleteButton = screen.getByTestId("delete-action-icon");
+    expect(deleteButton).toBeEnabled();
+    fireEvent.click(deleteButton);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("delete-dialog")).toBeInTheDocument();
+    });
+    const confirmDeleteBtn = screen.getByTestId(
+      "delete-dialog-continue-button"
+    );
+    expect(confirmDeleteBtn).toBeInTheDocument();
+    expect(
+      screen.getByTestId("delete-dialog-cancel-button")
+    ).toBeInTheDocument();
+
+    userEvent.click(confirmDeleteBtn);
+    await waitFor(() => expect(setCustomWarningMessages).toHaveBeenCalled());
   });
 
   it("should execute test cases", async () => {

--- a/src/components/editMeasure/testCases/components/testCaseLanding/qiCore/TestCaseList.test.tsx
+++ b/src/components/editMeasure/testCases/components/testCaseLanding/qiCore/TestCaseList.test.tsx
@@ -13,7 +13,6 @@ import {
 } from "../../../../../../api/ServiceContext";
 import {
   getCoverageValueFromHtml,
-  IMPORT_ERROR,
   removeHtmlCoverageHeader,
 } from "./TestCaseList";
 import calculationService, {
@@ -860,6 +859,53 @@ describe("TestCaseList component", () => {
 
     userEvent.click(confirmDeleteBtn);
     await waitFor(() => expect(setCustomWarningMessages).toHaveBeenCalled());
+  });
+
+  it("should handle response list of locked test cases on Test Case list page when delete button is clicked, and length is equal to selected", async () => {
+    useTestCaseServiceMock.mockImplementation(() => {
+      return {
+        ...useTestCaseServiceMockResolved,
+        deleteTestCases: jest.fn().mockRejectedValue({
+          response: {
+            status: 409,
+            data: {
+              message: "ID1",
+            },
+          },
+        }),
+      } as unknown as TestCaseServiceApi;
+    });
+
+    renderTestCaseListComponent();
+    await waitFor(() => {
+      const selectButton = screen.getByTestId(`test-case-title-0_select`);
+      const checkboxButton = within(selectButton).getByRole("checkbox");
+      expect(checkboxButton).toBeInTheDocument();
+      fireEvent.click(checkboxButton);
+      expect(checkboxButton).toBeChecked();
+    });
+
+    const deleteButton = screen.getByTestId("delete-action-icon");
+    expect(deleteButton).toBeEnabled();
+    fireEvent.click(deleteButton);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("delete-dialog")).toBeInTheDocument();
+    });
+    const confirmDeleteBtn = screen.getByTestId(
+      "delete-dialog-continue-button"
+    );
+    expect(confirmDeleteBtn).toBeInTheDocument();
+    expect(
+      screen.getByTestId("delete-dialog-cancel-button")
+    ).toBeInTheDocument();
+
+    userEvent.click(confirmDeleteBtn);
+    await waitFor(() => {
+      expect(screen.getByTestId("test-case-list-success")).toHaveTextContent(
+        `All the selected test cases are in-use by another user and could not be deleted.`
+      );
+    });
   });
 
   it("should execute test cases", async () => {

--- a/src/components/editMeasure/testCases/components/testCaseLanding/qiCore/TestCaseList.test.tsx
+++ b/src/components/editMeasure/testCases/components/testCaseLanding/qiCore/TestCaseList.test.tsx
@@ -824,7 +824,7 @@ describe("TestCaseList component", () => {
         ...useTestCaseServiceMockResolved,
         deleteTestCases: jest.fn().mockRejectedValue({
           response: {
-            status: 409,
+            status: 423,
             data: {
               message: "ID1,ID2",
             },
@@ -867,7 +867,7 @@ describe("TestCaseList component", () => {
         ...useTestCaseServiceMockResolved,
         deleteTestCases: jest.fn().mockRejectedValue({
           response: {
-            status: 409,
+            status: 423,
             data: {
               message: "ID1",
             },

--- a/src/components/editMeasure/testCases/components/testCaseLanding/qiCore/TestCaseList.tsx
+++ b/src/components/editMeasure/testCases/components/testCaseLanding/qiCore/TestCaseList.tsx
@@ -308,7 +308,30 @@ const TestCaseList = (props: TestCaseListProps) => {
       })
       .catch((err) => {
         console.error("deleteTestCases: err.message = " + err.message);
-        setErrors((prevState) => [...prevState, err.message]);
+        if (err?.response?.status == 409) {
+          if (
+            testCaseIds.length ===
+            err?.response?.data?.message?.split(",").length
+          ) {
+            setToastMessage(
+              "All the selected test cases are in-use by another user and could not be deleted."
+            );
+            setToastOpen(true);
+            setToastType("warning");
+          } else {
+            retrieveTestCases();
+            setCustomWarningMessages([
+              {
+                message:
+                  "Some of the selected test cases were deleted successfully, but the following test cases are in-use by another user and could not be deleted:",
+                details: err?.response?.data?.message?.split(","),
+                testDataId: "test-cases-in-use-warning",
+              },
+            ]);
+          }
+        } else {
+          setErrors((prevState) => [...prevState, err.message]);
+        }
       });
   };
 

--- a/src/components/editMeasure/testCases/components/testCaseLanding/qiCore/TestCaseList.tsx
+++ b/src/components/editMeasure/testCases/components/testCaseLanding/qiCore/TestCaseList.tsx
@@ -308,7 +308,7 @@ const TestCaseList = (props: TestCaseListProps) => {
       })
       .catch((err) => {
         console.error("deleteTestCases: err.message = " + err.message);
-        if (err?.response?.status == 409) {
+        if (err?.response?.status == 423) {
           if (
             testCaseIds.length ===
             err?.response?.data?.message?.split(",").length

--- a/src/components/editMeasure/testCases/components/testCaseLanding/qiCore/TestCaseList.tsx
+++ b/src/components/editMeasure/testCases/components/testCaseLanding/qiCore/TestCaseList.tsx
@@ -81,7 +81,13 @@ export const getCoverageValueFromHtml = (
 };
 
 const TestCaseList = (props: TestCaseListProps) => {
-  const { setErrors, setWarnings, setImportWarnings } = props;
+  const {
+    setErrors,
+    setWarnings,
+    setImportWarnings,
+    setShiftTestCaseDatesWarnings,
+    setCustomWarningMessages,
+  } = props;
   const { measureId, criteriaId } = useParams<{
     measureId: string;
     criteriaId: string;
@@ -661,6 +667,9 @@ const TestCaseList = (props: TestCaseListProps) => {
                         }
                         setWarnings={setWarnings}
                         page={page}
+                        setShiftTestCaseDatesWarnings={
+                          setShiftTestCaseDatesWarnings
+                        }
                       />
                       {currentSlice?.length > 0 && (
                         <Pagination

--- a/src/components/editMeasure/testCases/components/testCaseLanding/qiCore/TestCaseList.tsx
+++ b/src/components/editMeasure/testCases/components/testCaseLanding/qiCore/TestCaseList.tsx
@@ -290,21 +290,7 @@ const TestCaseList = (props: TestCaseListProps) => {
     setExecuteAllTestCases(false);
   };
 
-  const deleteTestCase = (testCaseId) => {
-    testCaseService.current
-      .deleteTestCaseByTestCaseId(measureId, testCaseId)
-      .then(() => {
-        retrieveTestCases();
-      })
-      .catch((err) => {
-        console.error(
-          "deleteTestCaseByTestCaseId: err.message = " + err.message
-        );
-        setErrors((prevState) => [...prevState, err.message]);
-      });
-  };
-
-  const deleteMultipleTestCases = () => {
+  const deleteTestCases = () => {
     const testCaseIds = selectedTestCases?.map((testCase) => testCase.id);
     testCaseService.current
       .deleteTestCases(measureId, testCaseIds)
@@ -661,7 +647,7 @@ const TestCaseList = (props: TestCaseListProps) => {
                         // test cases doesn't know how to sort by category
                         testCases={currentSlice}
                         canEdit={canEdit}
-                        deleteTestCase={deleteMultipleTestCases}
+                        deleteTestCase={deleteTestCases}
                         exportTestCase={exportTestCase}
                         measure={measure}
                         handleQiCloneTestCase={handleQiCloneTestCase}


### PR DESCRIPTION
## MADiE PR

Jira Ticket: [MAT-8919](https://jira.cms.gov/browse/MAT-8919)
(Optional) Related Tickets:

### Summary

Handle mixed test case deletion results due to one or more test cases being locked by other users. Use customWarnings to display failed deletions due to locked test cases.

#### Other Changes
- Remove unused api for individual test case deletion. All deletions use the multi endpoint.
- Generalize StatusHandler warning display and allow for custom text.
- Split out date shift warnings from general warnings.


### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included.
* [ ] No extemporaneous files are included (i.e Complied files or testing results).
* [ ] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).
* [ ] All CDN/Web dependencies are hosted internally (i.e MADiE-Root Repo).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
