### PR TITLE
MAT-8316: do not need to save Timing.repeat.bounds[x] choice type tha…

### DIFF
--- a/src/components/editMeasure/testCases/components/editTestCase/qiCore/LeftPanel/ElementsTab/builder/element/types/TimingComponent.test.tsx
+++ b/src/components/editMeasure/testCases/components/editTestCase/qiCore/LeftPanel/ElementsTab/builder/element/types/TimingComponent.test.tsx
@@ -169,7 +169,7 @@ function renderTimingComponent({
 }
 
 describe("TimingComponent", () => {
-  test("triggers Formik setFieldValue on interactions", async () => {
+  test("updates Formik values correctly for TimingComponent user interactions", async () => {
     renderTimingComponent({});
 
     // Event
@@ -192,69 +192,45 @@ describe("TimingComponent", () => {
     // Duration
     fireEvent.change(boundsInput, { target: { value: "Duration" } });
     await waitFor(() => {
-      expect(setFieldValueMock).toHaveBeenCalledWith(
-        "MedicationRequest.dosageInstruction[0].timing.repeat.bounds[x]",
-        "Duration"
-      );
-      expect(setFieldValueMock).toHaveBeenCalledWith(
-        "MedicationRequest.dosageInstruction[0].timing.repeat.boundsRange",
-        undefined
-      );
       expect(setFieldValueMock).toHaveBeenLastCalledWith(
         "MedicationRequest.dosageInstruction[0].timing.repeat.boundsPeriod",
         undefined
       );
+
+      expect(screen.getByDisplayValue("Not supported")).toBeInTheDocument();
     });
 
     // Range
     fireEvent.change(boundsInput, { target: { value: "Range" } });
     await waitFor(() => {
-      expect(setFieldValueMock).toHaveBeenCalledWith(
-        "MedicationRequest.dosageInstruction[0].timing.repeat.bounds[x]",
-        "Range"
-      );
-      expect(setFieldValueMock).toHaveBeenCalledWith(
-        "MedicationRequest.dosageInstruction[0].timing.repeat.boundsRange",
-        undefined
-      );
       expect(setFieldValueMock).toHaveBeenLastCalledWith(
         "MedicationRequest.dosageInstruction[0].timing.repeat.boundsPeriod",
         undefined
       );
+
+      expect(screen.getByDisplayValue("Not supported")).toBeInTheDocument();
     });
 
     // Period
     fireEvent.change(boundsInput, { target: { value: "Period" } });
     await waitFor(() => {
-      expect(setFieldValueMock).toHaveBeenCalledWith(
-        "MedicationRequest.dosageInstruction[0].timing.repeat.bounds[x]",
-        "Period"
-      );
-      expect(setFieldValueMock).toHaveBeenCalledWith(
-        "MedicationRequest.dosageInstruction[0].timing.repeat.boundsRange",
-        undefined
-      );
       expect(setFieldValueMock).toHaveBeenLastCalledWith(
         "MedicationRequest.dosageInstruction[0].timing.repeat.boundsPeriod",
-        undefined
+        {}
       );
+
+      expect(screen.queryByDisplayValue("Not supported")).toBeNull();
     });
 
     // "-" option to clear the bounds field
     fireEvent.change(boundsInput, { target: { value: "-" } });
     await waitFor(() => {
-      expect(setFieldValueMock).toHaveBeenCalledWith(
-        "MedicationRequest.dosageInstruction[0].timing.repeat.bounds",
-        undefined
-      );
-      expect(setFieldValueMock).toHaveBeenCalledWith(
-        "MedicationRequest.dosageInstruction[0].timing.repeat.boundsRange",
-        undefined
-      );
       expect(setFieldValueMock).toHaveBeenLastCalledWith(
         "MedicationRequest.dosageInstruction[0].timing.repeat.boundsPeriod",
         undefined
       );
+
+      expect(screen.queryByDisplayValue("Not supported")).toBeNull();
     });
 
     // Repeat.Count
@@ -450,7 +426,7 @@ describe("TimingComponent", () => {
     });
   });
 
-  test("TimingComponent calls Formik setFieldValue when QuantityIntervalInput (Range) low/high values change", async () => {
+  test("updates Formik setFieldValue when Period boundsPeriod start/end change", async () => {
     renderTimingComponent({
       initialValues: {
         MedicationRequest: {
@@ -458,63 +434,10 @@ describe("TimingComponent", () => {
             {
               timing: {
                 repeat: {
-                  bounds: { x: "Range" },
-                  boundsRange: {
-                    low: { value: 1, unit: "cm" },
-                    high: { value: 2, unit: "cm" },
+                  boundsPeriod: {
+                    start: "2016",
+                    end: "2017",
                   },
-                },
-              },
-            },
-          ],
-        },
-      },
-    });
-
-    const inputLow = screen.getByTestId(
-      "quantity-value-input-low"
-    ) as HTMLInputElement;
-    expect(inputLow.value).toBe("1");
-
-    const inputHigh = screen.getByTestId(
-      "quantity-value-input-high"
-    ) as HTMLInputElement;
-    expect(inputHigh.value).toBe("2");
-
-    // Change low value
-    fireEvent.change(inputLow, { target: { value: "10" } });
-    fireEvent.blur(inputLow);
-
-    // Change high value
-    fireEvent.change(inputHigh, { target: { value: "20" } });
-    fireEvent.blur(inputHigh);
-
-    await waitFor(() => {
-      expect(setFieldValueMock).toHaveBeenCalledWith(
-        "MedicationRequest.dosageInstruction[0].timing.repeat.boundsRange",
-        {
-          low: {
-            value: 10,
-            unit: "cm",
-          },
-          high: {
-            value: 20,
-            unit: "cm",
-          },
-        }
-      );
-    });
-  });
-
-  test("TimingComponent calls Formik setFieldValue when PeriodDateTimeComponent (Period) start/end values change", async () => {
-    renderTimingComponent({
-      initialValues: {
-        MedicationRequest: {
-          dosageInstruction: [
-            {
-              timing: {
-                repeat: {
-                  bounds: { x: "Period" },
                 },
               },
             },

--- a/src/components/editMeasure/testCases/components/editTestCase/qiCore/LeftPanel/ElementsTab/builder/element/types/TimingComponent.tsx
+++ b/src/components/editMeasure/testCases/components/editTestCase/qiCore/LeftPanel/ElementsTab/builder/element/types/TimingComponent.tsx
@@ -11,7 +11,6 @@ import { MenuItem } from "@mui/material";
 import { Select } from "@madie/madie-design-system/dist/react";
 import StringComponent from "./StringComponent";
 import PeriodDateTimeComponent from "./PeriodDateTimeComponent";
-import QuantityIntervalInput from "../../../../../../../common/quantityIntervalInput/QuantityIntervalInput";
 import "./TimingComponent.scss";
 
 const GROUP_GAP = "1.5rem";
@@ -33,10 +32,12 @@ const TimingComponent = ({
   const eventArrayPath = `${label}.event`;
   const eventValues = getIn(formik.values, eventArrayPath) || [""];
 
-  const boundsPath = `${label}.repeat.bounds[x]`;
-  const boundsValue = getIn(formik.values, boundsPath);
-  const boundsRangePath = `${label}.repeat.boundsRange`;
   const boundsPeriodPath = `${label}.repeat.boundsPeriod`;
+
+  const [selectedBounds, setSelectedBounds] = React.useState(() => {
+    if (getIn(formik.values, boundsPeriodPath)) return "Period";
+    return "-";
+  });
 
   const countPath = `${label}.repeat.count`;
   const countMaxPath = `${label}.repeat.countMax`;
@@ -64,11 +65,6 @@ const TimingComponent = ({
   const offsetPath = `${label}.repeat.offset`;
 
   const codePath = `${label}.code`;
-
-  const currentQuantityRatio = {
-    low: {},
-    high: {},
-  };
 
   return (
     <div id="timing-component">
@@ -102,20 +98,16 @@ const TimingComponent = ({
           data-testid="repeat-bounds"
           readOnly={!canEdit}
           size="small"
-          value={boundsValue}
+          value={selectedBounds}
           onChange={(e) => {
-            const selectedBounds = e.target.value;
+            const value = e.target.value;
+            setSelectedBounds(e.target.value);
 
-            if (selectedBounds === "-") {
-              // Clear the entire bounds object
-              formik.setFieldValue(`${label}.repeat.bounds`, undefined);
-            } else {
-              formik.setFieldValue(boundsPath, selectedBounds);
-            }
-
-            // Reset other bound fields
-            formik.setFieldValue(boundsRangePath, undefined);
-            formik.setFieldValue(boundsPeriodPath, undefined);
+            // Only initialize boundsPeriod for "Period"; clear it when any other option is selected
+            formik.setFieldValue(
+              boundsPeriodPath,
+              value === "Period" ? {} : undefined
+            );
           }}
           options={boundsOptions.map((boundsOption, i) => (
             <MenuItem
@@ -129,38 +121,22 @@ const TimingComponent = ({
         />
       </div>
 
-      {boundsValue === "Duration" && (
-        <StringComponent
-          label="Duration"
-          fieldRequired={fieldRequired}
-          canEdit={false}
-          value="Not supported"
-        />
-      )}
-
-      {boundsValue === "Range" && (
-        <QuantityIntervalInput
-          label={"Range"}
-          quantityInterval={
-            getIn(formik.values, boundsRangePath) || currentQuantityRatio
-          }
-          onQuantityIntervalChange={(val) => {
-            formik.setFieldTouched(boundsRangePath);
-            formik.setFieldValue(boundsRangePath, val);
-          }}
-          canEdit={canEdit}
-        />
-      )}
-
-      {boundsValue === "Period" && (
+      {selectedBounds === "Period" && (
         <PeriodDateTimeComponent
           label="Period"
           fieldRequired={false}
           canEdit={canEdit}
           value={getIn(formik.values, boundsPeriodPath) || {}}
-          onChange={(value) => {
-            formik.setFieldValue(boundsPeriodPath, value);
-          }}
+          onChange={(val) => formik.setFieldValue(boundsPeriodPath, val)}
+        />
+      )}
+
+      {(selectedBounds === "Duration" || selectedBounds === "Range") && (
+        <StringComponent
+          label={selectedBounds}
+          fieldRequired={fieldRequired}
+          canEdit={false}
+          value="Not supported"
         />
       )}
 


### PR DESCRIPTION
…t user selected to formik; make Range an unsupported element for now because a QI-Core Range component does not currently exist

- Remove storing of `bounds[x]` in Formik, as it's not needed and because it's not stored in test case json
- Use local state `selectedBounds` to drive rendering of bounds-related components
- Initialize `boundsPeriod` only for "Period"; clear it for other options
- Consolidate unsupported bounds ("Duration", "Range") into a single `StringComponent` with "Not supported". These two elements are unsupported because their QI-Core reusable components have not been implemented yet.

## MADiE PR

Jira Ticket: [MAT-8316](https://jira.cms.gov/browse/MAT-8316)
(Optional) Related Tickets:

### Summary

### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included.
* [ ] No extemporaneous files are included (i.e Complied files or testing results).
* [ ] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).
* [ ] All CDN/Web dependencies are hosted internally (i.e MADiE-Root Repo).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
