### PR TITLE
MAT-9357 disable run tests button when SDE and RAV return types mismatch

### DIFF
--- a/src/components/editMeasure/testCases/components/testCaseLanding/qdm/CreateCodeCoverageNavTabs.tsx
+++ b/src/components/editMeasure/testCases/components/testCaseLanding/qdm/CreateCodeCoverageNavTabs.tsx
@@ -108,6 +108,10 @@ export default function CreateCodeCoverageNavTabs(props: NavTabProps) {
     measure?.errors?.includes(
       MeasureErrorType.MISMATCH_CQL_POPULATION_RETURN_TYPES
     ) ||
+    measure?.errors?.includes(MeasureErrorType.MISMATCH_CQL_RISK_ADJUSTMENT) ||
+    measure?.errors?.includes(
+      MeasureErrorType.MISMATCH_CQL_SUPPLEMENTAL_DATA
+    ) ||
     _.isNil(measure?.groups) ||
     measure?.groups.length === 0 ||
     (measure?.testCaseConfiguration?.executeInvalidTestCases

--- a/src/components/editMeasure/testCases/components/testCaseLanding/qiCore/CreateCodeCoverageNavTabs.tsx
+++ b/src/components/editMeasure/testCases/components/testCaseLanding/qiCore/CreateCodeCoverageNavTabs.tsx
@@ -120,6 +120,10 @@ export default function CreateCodeCoverageNavTabs(props: NavTabProps) {
     measure?.errors?.includes(
       MeasureErrorType.MISMATCH_CQL_POPULATION_RETURN_TYPES
     ) ||
+    measure?.errors?.includes(MeasureErrorType.MISMATCH_CQL_RISK_ADJUSTMENT) ||
+    measure?.errors?.includes(
+      MeasureErrorType.MISMATCH_CQL_SUPPLEMENTAL_DATA
+    ) ||
     _.isNil(measure?.groups) ||
     measure?.groups.length === 0 ||
     (measure?.testCaseConfiguration?.executeInvalidTestCases

--- a/src/components/editMeasure/testCases/components/testCaseLanding/qiCore/TestCaseList.test.tsx
+++ b/src/components/editMeasure/testCases/components/testCaseLanding/qiCore/TestCaseList.test.tsx
@@ -1755,6 +1755,46 @@ describe("TestCaseList component", () => {
     expect(tabElement).not.toBeInTheDocument();
   });
 
+  it("should disable execute button if CQL risk adjustment type mismatch error exists on measure", async () => {
+    mockMeasure.createdBy = MEASURE_CREATEDBY;
+    mockMeasure.errors = [MeasureErrorType.MISMATCH_CQL_RISK_ADJUSTMENT];
+    renderTestCaseListComponent();
+
+    const table = await screen.findByTestId("test-case-tbl");
+    const tableRows = table.querySelectorAll("tbody tr");
+    await waitFor(() => {
+      expect(tableRows[2]).toHaveTextContent("N/A");
+      expect(tableRows[1]).toHaveTextContent("N/A");
+      expect(tableRows[0]).toHaveTextContent("Invalid");
+    });
+
+    const executeAllTestCasesButton = screen.getByRole("button", {
+      name: "Run Test(s)",
+    });
+
+    await waitFor(() => expect(executeAllTestCasesButton).toBeDisabled());
+  });
+
+  it("should disable execute button if CQL supplemental data type mismatch error exists on measure", async () => {
+    mockMeasure.createdBy = MEASURE_CREATEDBY;
+    mockMeasure.errors = [MeasureErrorType.MISMATCH_CQL_SUPPLEMENTAL_DATA];
+    renderTestCaseListComponent();
+
+    const table = await screen.findByTestId("test-case-tbl");
+    const tableRows = table.querySelectorAll("tbody tr");
+    await waitFor(() => {
+      expect(tableRows[2]).toHaveTextContent("N/A");
+      expect(tableRows[1]).toHaveTextContent("N/A");
+      expect(tableRows[0]).toHaveTextContent("Invalid");
+    });
+
+    const executeAllTestCasesButton = screen.getByRole("button", {
+      name: "Run Test(s)",
+    });
+
+    await waitFor(() => expect(executeAllTestCasesButton).toBeDisabled());
+  });
+
   describe("TestCaseList component with deleteMultipleTestCases", () => {
     it("should delete selected test cases", async () => {
       useTestCaseServiceMock.mockImplementation(() => {


### PR DESCRIPTION
## MADiE PR

Jira Ticket: [MAT-9357](https://jira.cms.gov/browse/MAT-9357)
(Optional) Related Tickets:

### Summary
disable run tests button when SDE and RAV return types mismatch

### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included.
* [ ] No extemporaneous files are included (i.e Complied files or testing results).
* [ ] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).
* [ ] All CDN/Web dependencies are hosted internally (i.e MADiE-Root Repo).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
