### PR TITLE
MAT-9325: unset overflow-y css to hide vertical scroll bars on data element table cells.

### DIFF
--- a/src/components/editMeasure/testCases/components/editTestCase/styles/DataElementsTable.scss
+++ b/src/components/editMeasure/testCases/components/editTestCase/styles/DataElementsTable.scss
@@ -97,7 +97,6 @@ $header-weight: 500;
         min-width: 360px;
 
         > div {
-          overflow-y: scroll;
           overflow-x: hidden;
           max-height: 250px;
           height: 100%;


### PR DESCRIPTION
## MADiE PR

Jira Ticket: [MAT-9325](https://jira.cms.gov/browse/MAT-9325)
(Optional) Related Tickets:

### Summary

Remove the CSS for `overflow-y` to hide the scrollbars, which look overly busy on Windows. Mac shows some simple gray bars.

#### Original
<img width="1419" height="367" alt="Screenshot 2025-11-18 at 11 29 05 AM" src="https://github.com/user-attachments/assets/20ad0435-e7d3-4b8a-b477-15f7ed574685" />

#### New
<img width="1419" height="367" alt="Screenshot 2025-11-18 at 11 28 57 AM" src="https://github.com/user-attachments/assets/8db1bd18-2971-471e-90ce-6f0dc4c0aeb9" />

#### Overflow Cell
<img width="1419" height="367" alt="Screenshot 2025-11-18 at 11 33 10 AM" src="https://github.com/user-attachments/assets/b8aec408-7844-425c-b273-e2eb4c7db399" />


### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included.
* [ ] No extemporaneous files are included (i.e Complied files or testing results).
* [ ] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).
* [ ] All CDN/Web dependencies are hosted internally (i.e MADiE-Root Repo).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
