### PR TITLE
MAT-8930: Update shift-dates API to handle new response structure

### DIFF
--- a/src/components/editMeasure/testCases/api/TestCaseServiceApi.test.tsx
+++ b/src/components/editMeasure/testCases/api/TestCaseServiceApi.test.tsx
@@ -303,10 +303,10 @@ describe("TestCaseServiceApi Tests", () => {
   });
 
   it("should shiftQdmTestCaseDates successfully", async () => {
-    const responseDto: TestCase = {
-      id: "1234",
-      json: "date2",
-    } as TestCase;
+    const responseDto = {
+      failed: [],
+      shifted: ["1234"],
+    };
 
     axios.put = jest.fn().mockResolvedValueOnce({ data: responseDto });
 
@@ -321,7 +321,8 @@ describe("TestCaseServiceApi Tests", () => {
       1
     );
     expect(axios.put).toBeCalledTimes(1);
-    expect(result).not.toEqual(testCase);
+    expect(result.shifted).toContain("1234");
+    expect(result.failed).toEqual([]);
   });
 
   it("should handle shiftQdmTestCaseDates failure with bad response", async () => {
@@ -404,13 +405,11 @@ describe("TestCaseServiceApi Tests", () => {
   });
 
   it("should handle shiftQiCoreTestCaseDates success", async () => {
-    const testCases: TestCase[] = [
-      {
-        id: "1234",
-        json: "date1",
-      },
-    ] as TestCase[];
-    axios.put = jest.fn().mockResolvedValueOnce({ data: testCases });
+    const responseDto = {
+      failed: [],
+      shifted: ["1234"],
+    };
+    axios.put = jest.fn().mockResolvedValueOnce({ data: responseDto });
 
     const result = await testCaseService.shiftQiCoreTestCaseDates(
       "testMeasureId",
@@ -418,6 +417,8 @@ describe("TestCaseServiceApi Tests", () => {
       1
     );
     expect(axios.put).toBeCalledTimes(1);
+    expect(result.shifted).toContain("1234");
+    expect(result.failed).toEqual([]);
   });
 
   it("should handle shiftQiCoreTestCaseDates failure with no response", async () => {
@@ -507,28 +508,20 @@ describe("TestCaseServiceApi Tests", () => {
   });
 
   it("should handle shiftAllQdmTestCaseDates successfully", async () => {
-    const responseDto: TestCase[] = [
-      {
-        id: "1234",
-        json: "date2",
-      },
-    ] as TestCase[];
+    const responseDto = {
+      failed: [],
+      shifted: ["1234"],
+    };
 
     axios.get = jest.fn().mockResolvedValueOnce({ data: responseDto });
-
-    const testCases: TestCase[] = [
-      {
-        id: "1234",
-        json: "date1",
-      },
-    ] as TestCase[];
 
     const result = await testCaseService.shiftAllQdmTestCaseDates(
       "testMeasureId",
       1
     );
     expect(axios.get).toBeCalledTimes(1);
-    expect(result[0]).not.toEqual(testCases[0]);
+    expect(result.shifted).toContain("1234");
+    expect(result.failed).toEqual([]);
   });
 
   it("should handle shiftAllQdmTestCaseDates failure with no response", async () => {
@@ -615,28 +608,20 @@ describe("TestCaseServiceApi Tests", () => {
   });
 
   it("should handle shiftAllQiCoreTestCaseDates successfully", async () => {
-    const responseDto: TestCase[] = [
-      {
-        id: "1234",
-        json: "date2",
-      },
-    ] as TestCase[];
+    const responseDto = {
+      failed: [],
+      shifted: ["1234"],
+    };
 
     axios.put = jest.fn().mockResolvedValueOnce({ data: responseDto });
-
-    const testCases: TestCase[] = [
-      {
-        id: "1234",
-        json: "date1",
-      },
-    ] as TestCase[];
 
     const result = await testCaseService.shiftAllQiCoreTestCaseDates(
       "testMeasureId",
       1
     );
     expect(axios.put).toBeCalledTimes(1);
-    expect(result[0]).not.toEqual(testCases[0]);
+    expect(result.shifted).toContain("1234");
+    expect(result.failed).toEqual([]);
   });
 
   it("should handle shiftAllQiCoreTestCaseDates failure with no response", async () => {

--- a/src/components/editMeasure/testCases/api/TestCaseServiceApi.test.tsx
+++ b/src/components/editMeasure/testCases/api/TestCaseServiceApi.test.tsx
@@ -122,18 +122,21 @@ describe("TestCaseServiceApi Tests", () => {
   });
 
   it("should handle successfully saving multiple test cases", async () => {
-    const responseDto: TestCase[] = [
-      {
-        id: "1234",
-        title: "TestCase1",
-        validResource: false,
-      } as TestCase,
-      {
-        id: "2345",
-        title: "TestCase2",
-        validResource: false,
-      } as TestCase,
-    ];
+    const responseDto = {
+      failed: [],
+      testCases: [
+        {
+          id: "1234",
+          title: "TestCase1",
+          validResource: false,
+        } as TestCase,
+        {
+          id: "2345",
+          title: "TestCase2",
+          validResource: false,
+        } as TestCase,
+      ],
+    };
 
     axios.post = jest.fn().mockResolvedValueOnce({ data: responseDto });
 
@@ -149,6 +152,8 @@ describe("TestCaseServiceApi Tests", () => {
     const response = await testCaseService.createTestCases("M123", testCases);
     expect(response).toBeTruthy();
     expect(response).toEqual(responseDto);
+    expect(response.testCases).toHaveLength(2);
+    expect(response.failed).toHaveLength(0);
   });
 
   it("should handle error calling saving multiple test cases", async () => {

--- a/src/components/editMeasure/testCases/api/useTestCaseServiceApi.ts
+++ b/src/components/editMeasure/testCases/api/useTestCaseServiceApi.ts
@@ -9,6 +9,7 @@ import {
   PopulationDto,
   TestCase,
   TestCaseExcelExportDto,
+  TestCaseImportOutcome,
   TestCaseImportRequest,
 } from "@madie/madie-models";
 import { useOktaTokens } from "@madie/madie-util";
@@ -38,6 +39,16 @@ export type QrdaRequestDTO = {
 export interface ShiftDatesResponse {
   failed: string[];
   shifted: string[];
+}
+
+export interface CreateTestCasesResponse {
+  failed: string[];
+  testCases: TestCase[];
+}
+
+export interface ImportTestCasesResponse {
+  outcomes: TestCaseImportOutcome[];
+  failed: string[];
 }
 
 export interface CopyResult {
@@ -181,7 +192,7 @@ export class TestCaseServiceApi {
   async importTestCases(
     measureId: string,
     testCasesImportRequest: TestCaseImportRequest[]
-  ): Promise<AxiosResponse> {
+  ): Promise<AxiosResponse<ImportTestCasesResponse>> {
     return await axios.put(
       `${this.baseUrl}/measures/${measureId}/test-cases/imports`,
       testCasesImportRequest,
@@ -235,9 +246,9 @@ export class TestCaseServiceApi {
   async createTestCases(
     measureId: string,
     testCases: TestCase[]
-  ): Promise<TestCase[]> {
+  ): Promise<CreateTestCasesResponse> {
     try {
-      const response = await axios.post<TestCase[]>(
+      const response = await axios.post<CreateTestCasesResponse>(
         `${this.baseUrl}/measures/${measureId}/test-cases/list`,
         testCases,
         {

--- a/src/components/editMeasure/testCases/api/useTestCaseServiceApi.ts
+++ b/src/components/editMeasure/testCases/api/useTestCaseServiceApi.ts
@@ -35,6 +35,11 @@ export type QrdaRequestDTO = {
   groupDTOs: QrdaGroupExportDTO[];
 };
 
+export interface ShiftDatesResponse {
+  failed: string[];
+  shifted: string[];
+}
+
 export interface CopyResult {
   copiedTestCases: TestCase[];
   didClearExpectedValues: boolean;
@@ -309,7 +314,7 @@ export class TestCaseServiceApi {
     measureId: string,
     testCaseIds: string[],
     shifted: number
-  ) {
+  ): Promise<ShiftDatesResponse> {
     try {
       const response = await axios.put(
         `${this.baseUrl}/measures/${measureId}/test-cases/qdm/shift-dates`,
@@ -338,7 +343,7 @@ export class TestCaseServiceApi {
     measureId: string,
     testCaseIds: string[],
     shifted: number
-  ) {
+  ): Promise<ShiftDatesResponse> {
     try {
       const response = await axios.put(
         `${this.baseUrl}/measures/${measureId}/test-cases/qicore/shift-dates`,
@@ -363,7 +368,10 @@ export class TestCaseServiceApi {
     }
   }
 
-  async shiftAllQdmTestCaseDates(measureId: string, shifted: number) {
+  async shiftAllQdmTestCaseDates(
+    measureId: string,
+    shifted: number
+  ): Promise<ShiftDatesResponse> {
     try {
       const response = await axios.get(
         `${this.baseUrl}/measures/${measureId}/test-cases/qdm/shift-all-dates`,
@@ -390,7 +398,7 @@ export class TestCaseServiceApi {
   async shiftAllQiCoreTestCaseDates(
     measureId: string,
     shifted: number
-  ): Promise<string[]> {
+  ): Promise<ShiftDatesResponse> {
     try {
       const response = await axios.put(
         `${this.baseUrl}/measures/${measureId}/test-cases/qicore/shift-all-dates`,

--- a/src/components/editMeasure/testCases/components/editTestCase/qdm/EditTestCase.test.tsx
+++ b/src/components/editMeasure/testCases/components/editTestCase/qdm/EditTestCase.test.tsx
@@ -688,7 +688,9 @@ describe("EditTestCase QDM Component", () => {
     const raceOptions = await screen.findAllByRole("option");
     expect(raceOptions.length).toBe(4);
     userEvent.click(raceOptions[3]);
-    expect(raceSelector).toHaveTextContent("White");
+    await waitFor(() => {
+      expect(raceSelector).toHaveTextContent("White");
+    });
 
     // Gender dropdown change
     const genderSelector = screen.getByRole("combobox", { name: "Sex" });
@@ -698,7 +700,9 @@ describe("EditTestCase QDM Component", () => {
     const genderOptions = await screen.findAllByRole("option");
     expect(genderOptions.length).toBe(3);
     userEvent.click(genderOptions[2]);
-    expect(genderSelector).toHaveTextContent("Male (finding)");
+    await waitFor(() => {
+      expect(genderSelector).toHaveTextContent("Male (finding)");
+    });
 
     // Ethnicity dropdown change
     const ethnicitySelector = screen.getByRole("combobox", {
@@ -710,7 +714,9 @@ describe("EditTestCase QDM Component", () => {
     const ethnicityOptions = await screen.findAllByRole("option");
     expect(ethnicityOptions.length).toBe(3);
     userEvent.click(ethnicityOptions[1]);
-    expect(ethnicitySelector).toHaveTextContent("Hispanic or Latino");
+    await waitFor(() => {
+      expect(ethnicitySelector).toHaveTextContent("Hispanic or Latino");
+    });
 
     // Living Status dropdown change
     const livingStatusSelector = screen.getByRole("combobox", {
@@ -721,12 +727,19 @@ describe("EditTestCase QDM Component", () => {
     const livingStatusOptions = await screen.findAllByRole("option");
     expect(livingStatusOptions.length).toBe(2);
     userEvent.click(livingStatusOptions[1]);
-    expect(livingStatusSelector).toHaveTextContent("Expired");
+    await waitFor(() => {
+      expect(livingStatusSelector).toHaveTextContent("Expired");
+    });
+
+    // Wait for form state to update before clicking discard
+    await waitFor(() => {
+      const discardButton = screen.getByTestId("ds-btn");
+      expect(discardButton).not.toBeDisabled();
+    });
 
     // Discard button
     const discardButton = screen.getByTestId("ds-btn");
     expect(discardButton).toBeInTheDocument();
-    expect(discardButton).not.toBeDisabled();
     userEvent.click(discardButton);
 
     const discardConfirm = screen.getByTestId("discard-dialog-continue-button");
@@ -741,7 +754,7 @@ describe("EditTestCase QDM Component", () => {
     expect(genderSelector).toHaveTextContent("Select a Gender");
     expect(ethnicitySelector).toHaveTextContent("Select an Ethnicity");
     expect(livingStatusSelector).toHaveTextContent("Living");
-  });
+  }, 45000);
 
   it("test update test case successfully with success toast", async () => {
     testCase.json = JSON.stringify(testCaseJson);
@@ -1023,8 +1036,11 @@ describe("EditTestCase QDM Component", () => {
       userEvent.type(descriptionInput, "testtestsetse");
     });
 
+    await waitFor(() => {
+      const saveButton = getByRole("button", { name: "Save" });
+      expect(saveButton).toBeEnabled();
+    });
     const saveButton = getByRole("button", { name: "Save" });
-    expect(saveButton).toBeEnabled();
     act(() => {
       fireEvent.click(saveButton);
     });
@@ -1076,8 +1092,11 @@ describe("EditTestCase QDM Component", () => {
       userEvent.type(descriptionInput, "testtestsetse");
     });
 
+    await waitFor(() => {
+      const saveButton = getByRole("button", { name: "Save" });
+      expect(saveButton).toBeEnabled();
+    });
     const saveButton = getByRole("button", { name: "Save" });
-    expect(saveButton).toBeEnabled();
     act(() => {
       fireEvent.click(saveButton);
     });

--- a/src/components/editMeasure/testCases/components/testCaseConfiguration/testCaseData/TestCaseData.test.tsx
+++ b/src/components/editMeasure/testCases/components/testCaseConfiguration/testCaseData/TestCaseData.test.tsx
@@ -673,4 +673,75 @@ describe("TestCaseData", () => {
       ).toHaveTextContent(SHIFT_TEST_CASE_DATES_ERROR_TEST_CASE_LOCKED)
     );
   });
+
+  it("should handle QDM response with failed test cases", async () => {
+    const failedResponseDto = {
+      failed: ["Test case 1 failed to shift", "Test case 2 failed to shift"],
+      shifted: ["1234"],
+    };
+    const shiftAllTestCaseDatesApiMock = jest
+      .fn()
+      .mockResolvedValueOnce(failedResponseDto);
+    useTestCaseServiceMock.mockImplementationOnce(() => {
+      return {
+        shiftAllQdmTestCaseDates: shiftAllTestCaseDatesApiMock,
+      } as unknown as TestCaseServiceApi;
+    });
+
+    renderTestCaseDataComponent();
+    const shiftTestCaseDatesInput = screen.getByRole("spinbutton", {
+      name: "Shift Test Case Dates",
+    }) as HTMLInputElement;
+    const saveButton = screen.getByRole("button", { name: "Save" });
+
+    userEvent.type(shiftTestCaseDatesInput, "5");
+    expect(saveButton).toBeEnabled();
+
+    act(() => {
+      fireEvent.click(saveButton);
+    });
+
+    await waitFor(() =>
+      expect(mockShiftTestCaseDatesWarning.mock.calls).toHaveLength(1)
+    );
+    expect(mockShiftTestCaseDatesWarning).toHaveBeenCalledWith(
+      expect.any(Function)
+    );
+  });
+
+  it("should handle QI-Core response with failed test cases", async () => {
+    measureStore.state.mockImplementationOnce(() => qiCoreMeasure);
+    const failedResponseDto = {
+      failed: ["Test case 1 failed to shift", "Test case 2 failed to shift"],
+      shifted: ["1234"],
+    };
+    const shiftAllTestCaseDatesApiMock = jest
+      .fn()
+      .mockResolvedValueOnce(failedResponseDto);
+    useTestCaseServiceMock.mockImplementationOnce(() => {
+      return {
+        shiftAllQiCoreTestCaseDates: shiftAllTestCaseDatesApiMock,
+      } as unknown as TestCaseServiceApi;
+    });
+
+    renderTestCaseDataComponent();
+    const shiftTestCaseDatesInput = screen.getByRole("spinbutton", {
+      name: "Shift Test Case Dates",
+    }) as HTMLInputElement;
+    const saveButton = screen.getByRole("button", { name: "Save" });
+
+    userEvent.type(shiftTestCaseDatesInput, "5");
+    expect(saveButton).toBeEnabled();
+
+    act(() => {
+      fireEvent.click(saveButton);
+    });
+
+    await waitFor(() =>
+      expect(mockShiftTestCaseDatesWarning.mock.calls).toHaveLength(1)
+    );
+    expect(mockShiftTestCaseDatesWarning).toHaveBeenCalledWith(
+      expect.any(Function)
+    );
+  });
 });

--- a/src/components/editMeasure/testCases/components/testCaseConfiguration/testCaseData/TestCaseData.test.tsx
+++ b/src/components/editMeasure/testCases/components/testCaseConfiguration/testCaseData/TestCaseData.test.tsx
@@ -51,12 +51,10 @@ const measure = {
 
 const qiCoreMeasure = { ...measure, model: "QI-Core v4.1.1" } as Measure;
 
-const responseDto: TestCase[] = [
-  {
-    id: "1234",
-    json: "date2",
-  },
-] as TestCase[];
+const responseDto = {
+  failed: [],
+  shifted: ["1234"],
+};
 
 jest.mock("@madie/madie-util", () => ({
   measureStore: {
@@ -282,7 +280,7 @@ describe("TestCaseData", () => {
   it("should successfully shift all test case dates", async () => {
     const shiftAllTestCaseDatesApiMock = jest
       .fn()
-      .mockResolvedValueOnce({ data: responseDto });
+      .mockResolvedValueOnce(responseDto);
     useTestCaseServiceMock.mockImplementationOnce(() => {
       return {
         shiftAllQdmTestCaseDates: shiftAllTestCaseDatesApiMock,
@@ -406,7 +404,7 @@ describe("TestCaseData", () => {
 
     const shiftAllTestCaseDatesApiMock = jest
       .fn()
-      .mockResolvedValueOnce({ data: responseDto });
+      .mockResolvedValueOnce(responseDto);
     useTestCaseServiceMock.mockImplementationOnce(() => {
       return {
         shiftAllQiCoreTestCaseDates: shiftAllTestCaseDatesApiMock,
@@ -493,7 +491,7 @@ describe("TestCaseData", () => {
     }));
     const shiftAllTestCaseDatesApiMock = jest
       .fn()
-      .mockResolvedValueOnce({ data: responseDto });
+      .mockResolvedValueOnce(responseDto);
     useTestCaseServiceMock.mockImplementationOnce(() => {
       return {
         shiftAllQdmTestCaseDates: shiftAllTestCaseDatesApiMock,
@@ -538,9 +536,13 @@ describe("TestCaseData", () => {
     (useFeatureFlags as jest.Mock).mockClear().mockImplementation(() => ({
       Locking: true,
     }));
+    const failedResponseDto = {
+      failed: ["1234"],
+      shifted: [],
+    };
     const shiftAllTestCaseDatesApiMock = jest
       .fn()
-      .mockResolvedValueOnce(responseDto);
+      .mockResolvedValueOnce(failedResponseDto);
     useTestCaseServiceMock.mockImplementationOnce(() => {
       return {
         shiftAllQiCoreTestCaseDates: shiftAllTestCaseDatesApiMock,

--- a/src/components/editMeasure/testCases/components/testCaseConfiguration/testCaseData/TestCaseData.tsx
+++ b/src/components/editMeasure/testCases/components/testCaseConfiguration/testCaseData/TestCaseData.tsx
@@ -90,12 +90,19 @@ const TestCaseData = (props: TestCaseListProps) => {
           measure.id,
           parseInt(formik.values.shiftTestCaseDates)
         )
-        .then(() => {
-          handleToast(
-            "success",
-            `All Test Case dates successfully shifted.`,
-            true
-          );
+        .then((response) => {
+          if (response.failed.length === 0) {
+            handleToast(
+              "success",
+              `All Test Case dates successfully shifted.`,
+              true
+            );
+          } else {
+            setShiftTestCaseDatesWarnings((prevState) => [
+              ...prevState,
+              ...response.failed,
+            ]);
+          }
         })
         .catch((err) => {
           if (featureFlags?.Locking) {
@@ -113,11 +120,11 @@ const TestCaseData = (props: TestCaseListProps) => {
           measure.id,
           parseInt(formik.values.shiftTestCaseDates)
         )
-        .then((failedTestCases) => {
-          if (failedTestCases.length > 0) {
+        .then((response) => {
+          if (response.failed.length > 0) {
             setShiftTestCaseDatesWarnings((prevState) => [
               ...prevState,
-              ...failedTestCases,
+              ...response.failed,
             ]);
           } else {
             handleToast(

--- a/src/components/editMeasure/testCases/components/testCaseLanding/common/shiftDates/ShiftDatesDialog.test.tsx
+++ b/src/components/editMeasure/testCases/components/testCaseLanding/common/shiftDates/ShiftDatesDialog.test.tsx
@@ -89,7 +89,7 @@ describe("Shift Test Case Dates Dialog", () => {
   });
 
   test("Should shift dates for qdm measure and shows success toast", async () => {
-    const responseData: string[] = [];
+    const responseData = { failed: [], shifted: [] };
     const shiftQdmTestCaseDates = jest.fn().mockResolvedValueOnce(responseData);
     useTestCaseServiceMock.mockImplementationOnce(() => {
       return {
@@ -145,9 +145,10 @@ describe("Shift Test Case Dates Dialog", () => {
   });
 
   test("Should shift dates for qdm measure and shows warning", async () => {
-    const responseData: string[] = [
-      "Warning: Test Case 1 dates could not be shifted.",
-    ];
+    const responseData = {
+      failed: ["Warning: Test Case 1 dates could not be shifted."],
+      shifted: [],
+    };
     const shiftQdmTestCaseDates = jest.fn().mockResolvedValueOnce(responseData);
     useTestCaseServiceMock.mockImplementationOnce(() => {
       return {
@@ -261,8 +262,8 @@ describe("Shift Test Case Dates Dialog", () => {
     });
   });
 
-  test("Should shift dates for qicore measure and show success toast", async () => {
-    const responseData: string[] = [];
+  test("Should shift dates for qi-core measure and shows success toast", async () => {
+    const responseData = { failed: [], shifted: [] };
     const shiftQiCoreTestCaseDates = jest
       .fn()
       .mockResolvedValueOnce(responseData);
@@ -319,10 +320,11 @@ describe("Shift Test Case Dates Dialog", () => {
     });
   });
 
-  test("Should shift dates for qicore measure and show warning", async () => {
-    const responseData: string[] = [
-      "Warning: Test Case 1 dates could not be shifted.",
-    ];
+  test("Should shift dates for qi-core measure and shows warning", async () => {
+    const responseData = {
+      failed: ["Warning: Test Case 1 dates could not be shifted."],
+      shifted: [],
+    };
     const shiftQiCoreTestCaseDates = jest
       .fn()
       .mockResolvedValueOnce(responseData);
@@ -442,7 +444,9 @@ describe("Shift Test Case Dates Dialog", () => {
     (useFeatureFlags as jest.Mock).mockClear().mockImplementation(() => ({
       Locking: true,
     }));
-    const shiftTestCaseDatesApiMock = jest.fn().mockResolvedValueOnce([]);
+    const shiftTestCaseDatesApiMock = jest
+      .fn()
+      .mockResolvedValueOnce({ failed: [], shifted: [] });
     useTestCaseServiceMock.mockImplementationOnce(() => {
       return {
         shiftQdmTestCaseDates: shiftTestCaseDatesApiMock,

--- a/src/components/editMeasure/testCases/components/testCaseLanding/common/shiftDates/ShiftDatesDialog.tsx
+++ b/src/components/editMeasure/testCases/components/testCaseLanding/common/shiftDates/ShiftDatesDialog.tsx
@@ -55,14 +55,14 @@ const ShiftDatesDialog = ({
           value.shiftDatesInput
         )
         .then((response) => {
-          if (response.length === 0) {
+          if (response.failed.length === 0) {
             setToastOpen(true);
             setToastType("success");
             setToastMessage(`All Test Case dates successfully shifted.`);
           } else {
             setShiftTestCaseDatesWarnings((prevState) => [
               ...prevState,
-              ...response,
+              ...response.failed,
             ]);
           }
         })
@@ -79,14 +79,14 @@ const ShiftDatesDialog = ({
           value.shiftDatesInput
         )
         .then((response) => {
-          if (response.length === 0) {
+          if (response.failed.length === 0) {
             setToastOpen(true);
             setToastType("success");
             setToastMessage(`All Test Case dates successfully shifted.`);
           } else {
             setShiftTestCaseDatesWarnings((prevState) => [
               ...prevState,
-              ...response,
+              ...response.failed,
             ]);
           }
         })

--- a/src/components/editMeasure/testCases/components/testCaseLanding/qdm/TestCaseList.test.tsx
+++ b/src/components/editMeasure/testCases/components/testCaseLanding/qdm/TestCaseList.test.tsx
@@ -1100,7 +1100,7 @@ const useTestCaseServiceMockResolved = {
   getTestCaseSeriesForMeasure: jest
     .fn()
     .mockResolvedValue(["Series 1", "Series 2"]),
-  createTestCases: jest.fn().mockResolvedValue([]),
+  createTestCases: jest.fn().mockResolvedValue({ failed: [], testCases: [] }),
   importTestCasesQDM: jest.fn().mockResolvedValue([]),
   exportQRDA: jest.fn().mockResolvedValue([]),
 } as unknown as TestCaseServiceApi;

--- a/src/components/editMeasure/testCases/components/testCaseLanding/qdm/TestCaseList.test.tsx
+++ b/src/components/editMeasure/testCases/components/testCaseLanding/qdm/TestCaseList.test.tsx
@@ -1723,7 +1723,10 @@ describe("TestCaseList component", () => {
   });
 
   it("should attempt to shift the dates in test case when the Save button within the shift test case dates dialogue is clicked and display an error message", async () => {
-    const responseData: string[] = ["testId1", "testId2"];
+    const responseData = {
+      failed: ["testId1", "testId2"],
+      shifted: [],
+    };
 
     const shiftQdmTestCaseDates = jest.fn().mockResolvedValueOnce(responseData);
 

--- a/src/components/editMeasure/testCases/components/testCaseLanding/qiCore/TestCaseList.test.tsx
+++ b/src/components/editMeasure/testCases/components/testCaseLanding/qiCore/TestCaseList.test.tsx
@@ -1650,7 +1650,10 @@ describe("TestCaseList component", () => {
   });
 
   it("should attempt to shift the dates in test case when the Save button within the shift test case dates dialogue is clicked and display an error message", async () => {
-    const responseData: string[] = ["testId1", "testId2"];
+    const responseData = {
+      failed: ["testId1", "testId2"],
+      shifted: [],
+    };
 
     const shiftQiCoreTestCaseDates = jest
       .fn()

--- a/src/components/editMeasure/testCases/components/testCaseLanding/qiCore/TestCaseList.test.tsx
+++ b/src/components/editMeasure/testCases/components/testCaseLanding/qiCore/TestCaseList.test.tsx
@@ -484,7 +484,7 @@ const useTestCaseServiceMockResolved = {
   getTestCaseSeriesForMeasure: jest
     .fn()
     .mockResolvedValue(["Series 1", "Series 2"]),
-  createTestCases: jest.fn().mockResolvedValue([]),
+  createTestCases: jest.fn().mockResolvedValue({ failed: [], testCases: [] }),
   exportTestCase: jest.fn().mockResolvedValue(
     new Blob([JSON.stringify("exported test data")], {
       type: "application/json",
@@ -1474,12 +1474,12 @@ describe("TestCaseList component", () => {
     const mockedOutcome: TestCaseImportOutcome[] = [
       {
         patientId: patientId1,
-        message: null,
+        message: "",
         successful: true,
       },
       {
         patientId: patientId2,
-        message: null,
+        message: "",
         successful: true,
       },
     ];
@@ -1491,7 +1491,9 @@ describe("TestCaseList component", () => {
           .fn()
           .mockResolvedValue(["Series 1", "Series 2"]),
         scanImportFile: jest.fn().mockResolvedValue(mockScanResult),
-        importTestCases: jest.fn().mockResolvedValue({ data: mockedOutcome }),
+        importTestCases: jest
+          .fn()
+          .mockResolvedValue({ data: { outcomes: mockedOutcome, failed: [] } }),
       } as unknown as TestCaseServiceApi;
     });
 
@@ -1577,7 +1579,7 @@ describe("TestCaseList component", () => {
       },
       {
         patientId: patientId2,
-        message: null,
+        message: "",
         successful: true,
       },
     ];
@@ -1589,7 +1591,9 @@ describe("TestCaseList component", () => {
           .fn()
           .mockResolvedValue(["Series 1", "Series 2"]),
         scanImportFile: jest.fn().mockResolvedValue(mockScanResult),
-        importTestCases: jest.fn().mockResolvedValue({ data: mockedOutcome }),
+        importTestCases: jest
+          .fn()
+          .mockResolvedValue({ data: { outcomes: mockedOutcome, failed: [] } }),
       } as unknown as TestCaseServiceApi;
     });
 

--- a/src/components/editMeasure/testCases/components/testCaseLanding/qiCore/TestCaseList.tsx
+++ b/src/components/editMeasure/testCases/components/testCaseLanding/qiCore/TestCaseList.tsx
@@ -507,7 +507,9 @@ const TestCaseList = (props: TestCaseListProps) => {
         measureId,
         testCaseImportRequest
       );
-      const testCaseImportOutcome: TestCaseImportOutcome[] = response.data;
+      const importResponse = response.data;
+      const testCaseImportOutcome: TestCaseImportOutcome[] =
+        importResponse.outcomes;
       const failedImports = testCaseImportOutcome.filter((outcome) => {
         if (outcome.message) return outcome;
       });


### PR DESCRIPTION
- Add ShiftDatesResponse interface with failed and shifted arrays
- Update all four shift date methods to return ShiftDatesResponse:
  - shiftQdmTestCaseDates
  - shiftQiCoreTestCaseDates
  - shiftAllQdmTestCaseDates
  - shiftAllQiCoreTestCaseDates
- Update ShiftDatesDialog to check response.failed.length instead of response.length
- Update TestCaseData to handle new response structure for both QDM and QI-Core
- Update all test files to use new response structure:
  - ShiftDatesDialog.test.tsx
  - TestCaseList.test.tsx (QDM and QI-Core)
  - TestCaseServiceApi.test.tsx
  - TestCaseData.test.tsx

The server now returns {failed: string[], shifted: string[]} instead of string[] Success is determined by checking if failed array is empty

## MADiE PR

Jira Ticket: [MAT-8930](https://jira.cms.gov/browse/MAT-8930)
(Optional) Related Tickets:

### Summary

### All Submissions
* [X] This PR has the JIRA linked.
* [X] Required tests are included.
* [X] No extemporaneous files are included (i.e Complied files or testing results).
* [X] This PR is merging into the **correct branch**.
* [X] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).
* [ ] All CDN/Web dependencies are hosted internally (i.e MADiE-Root Repo).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
