### PR TITLE
MAT-9321: fix period component crashing when typing

### DIFF
--- a/src/components/editMeasure/testCases/components/editTestCase/qiCore/LeftPanel/ElementsTab/builder/element/types/PeriodDateTimeComponent.test.tsx
+++ b/src/components/editMeasure/testCases/components/editTestCase/qiCore/LeftPanel/ElementsTab/builder/element/types/PeriodDateTimeComponent.test.tsx
@@ -235,6 +235,46 @@ describe("PeriodDateTimeComponent", () => {
 
     expect(onChange).not.toHaveBeenCalled();
   });
+
+  it("does not trigger onChange when user types an invalid start date and blurs", async () => {
+    const onChange = jest.fn();
+    render(
+      <PeriodDateTimeComponent
+        canEdit={true}
+        fieldRequired={false}
+        value={{ end: "2024-10-01" }}
+        onChange={onChange}
+        label="DateTime"
+      />
+    );
+
+    const startInputWrapper = screen.getByTestId(
+      "start-YYYY-MM-DD-field-DateTime"
+    );
+    const startInput = startInputWrapper.querySelector("input");
+    fireEvent.change(startInput, { target: { value: "invalid-date" } });
+    fireEvent.blur(startInput);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("does not trigger onChange when user types an invalid end date and blurs", async () => {
+    const onChange = jest.fn();
+    render(
+      <PeriodDateTimeComponent
+        canEdit={true}
+        fieldRequired={false}
+        value={{ end: "2024-10-01" }}
+        onChange={onChange}
+        label="DateTime"
+      />
+    );
+
+    const endInputWrapper = screen.getByTestId("end-YYYY-MM-DD-field-DateTime");
+    const endInput = endInputWrapper.querySelector("input");
+    fireEvent.change(endInput, { target: { value: "invalid-date" } });
+    fireEvent.blur(endInput);
+    expect(onChange).not.toHaveBeenCalled();
+  });
 });
 
 describe("PeriodDateTimeComponent useEffect", () => {

--- a/src/components/editMeasure/testCases/components/editTestCase/qiCore/LeftPanel/ElementsTab/builder/element/types/PeriodDateTimeComponent.tsx
+++ b/src/components/editMeasure/testCases/components/editTestCase/qiCore/LeftPanel/ElementsTab/builder/element/types/PeriodDateTimeComponent.tsx
@@ -207,28 +207,28 @@ const PeriodDateTimeComponent = ({
               placeholder={format ? formatOptionRenderMap[format] : ""}
               id={`start-${format || "year"}-field-${label}`}
               onChange={(newDate) => {
-                if (!newDate) return;
+                if (!newDate || newDate.format(format) === "Invalid Date") {
+                  return;
+                }
 
-                if (newDate.format(format) !== "Invalid Date") {
-                  const dateUTC = dayjs.utc(newDate);
-                  setStartDate(dateUTC);
-                  if (format === DATE_TIME_ZONE_FORMAT && startTime) {
-                    // Merge date and time
-                    const merged = dateUTC
-                      .hour(startTime.hour())
-                      .minute(startTime.minute())
-                      .second(startTime.second());
-                    setStartDate(merged);
-                    onChange({
-                      start: merged.format(format),
-                      end: endDate ? endDate.format(format) : "",
-                    });
-                  } else {
-                    onChange({
-                      start: dateUTC.format(format),
-                      end: endDate ? endDate.format(format) : "",
-                    });
-                  }
+                const dateUTC = dayjs.utc(newDate);
+                setStartDate(dateUTC);
+                if (format === DATE_TIME_ZONE_FORMAT && startTime) {
+                  // Merge date and time
+                  const merged = dateUTC
+                    .hour(startTime.hour())
+                    .minute(startTime.minute())
+                    .second(startTime.second());
+                  setStartDate(merged);
+                  onChange({
+                    start: merged.format(format),
+                    end: endDate ? endDate.format(format) : "",
+                  });
+                } else {
+                  onChange({
+                    start: dateUTC.format(format),
+                    end: endDate ? endDate.format(format) : "",
+                  });
                 }
               }}
               onBlur={() => {}}
@@ -289,28 +289,28 @@ const PeriodDateTimeComponent = ({
               placeholder={format ? formatOptionRenderMap[format] : ""}
               id={`end-${format || "year"}-field-${label}`}
               onChange={(newDate) => {
-                if (!newDate) return;
+                if (!newDate || newDate.format(format) === "Invalid Date") {
+                  return;
+                }
 
-                if (newDate.format(format) !== "Invalid Date") {
-                  const dateUTC = dayjs.utc(newDate);
-                  setEndDate(dateUTC);
-                  if (format === DATE_TIME_ZONE_FORMAT && endTime) {
-                    // Merge date and time
-                    const merged = dateUTC
-                      .hour(endTime.hour())
-                      .minute(endTime.minute())
-                      .second(endTime.second());
-                    setEndDate(merged);
-                    onChange({
-                      start: startDate ? startDate.format(format) : "",
-                      end: merged.format(format),
-                    });
-                  } else {
-                    onChange({
-                      start: startDate ? startDate.format(format) : "",
-                      end: dateUTC.format(format),
-                    });
-                  }
+                const dateUTC = dayjs.utc(newDate);
+                setEndDate(dateUTC);
+                if (format === DATE_TIME_ZONE_FORMAT && endTime) {
+                  // Merge date and time
+                  const merged = dateUTC
+                    .hour(endTime.hour())
+                    .minute(endTime.minute())
+                    .second(endTime.second());
+                  setEndDate(merged);
+                  onChange({
+                    start: startDate ? startDate.format(format) : "",
+                    end: merged.format(format),
+                  });
+                } else {
+                  onChange({
+                    start: startDate ? startDate.format(format) : "",
+                    end: dateUTC.format(format),
+                  });
                 }
               }}
               onBlur={() => {}}

--- a/src/components/editMeasure/testCases/components/editTestCase/qiCore/LeftPanel/ElementsTab/builder/element/types/PeriodDateTimeComponent.tsx
+++ b/src/components/editMeasure/testCases/components/editTestCase/qiCore/LeftPanel/ElementsTab/builder/element/types/PeriodDateTimeComponent.tsx
@@ -197,6 +197,7 @@ const PeriodDateTimeComponent = ({
           >
             <DateField
               label="Start Date"
+              format={format}
               required={fieldRequired}
               error={error.start}
               helperText={helperText.start}
@@ -207,24 +208,27 @@ const PeriodDateTimeComponent = ({
               id={`start-${format || "year"}-field-${label}`}
               onChange={(newDate) => {
                 if (!newDate) return;
-                const dateUTC = dayjs.utc(newDate);
-                setStartDate(dateUTC);
-                if (format === DATE_TIME_ZONE_FORMAT && startTime) {
-                  // Merge date and time
-                  const merged = dateUTC
-                    .hour(startTime.hour())
-                    .minute(startTime.minute())
-                    .second(startTime.second());
-                  setStartDate(merged);
-                  onChange({
-                    start: merged.format(format),
-                    end: endDate ? endDate.format(format) : "",
-                  });
-                } else {
-                  onChange({
-                    start: dateUTC.format(format),
-                    end: endDate ? endDate.format(format) : "",
-                  });
+
+                if (newDate.format(format) !== "Invalid Date") {
+                  const dateUTC = dayjs.utc(newDate);
+                  setStartDate(dateUTC);
+                  if (format === DATE_TIME_ZONE_FORMAT && startTime) {
+                    // Merge date and time
+                    const merged = dateUTC
+                      .hour(startTime.hour())
+                      .minute(startTime.minute())
+                      .second(startTime.second());
+                    setStartDate(merged);
+                    onChange({
+                      start: merged.format(format),
+                      end: endDate ? endDate.format(format) : "",
+                    });
+                  } else {
+                    onChange({
+                      start: dateUTC.format(format),
+                      end: endDate ? endDate.format(format) : "",
+                    });
+                  }
                 }
               }}
               onBlur={() => {}}
@@ -275,6 +279,7 @@ const PeriodDateTimeComponent = ({
           >
             <DateField
               label="End Date"
+              format={format}
               required={fieldRequired}
               error={error.end}
               helperText={helperText.end}
@@ -285,24 +290,27 @@ const PeriodDateTimeComponent = ({
               id={`end-${format || "year"}-field-${label}`}
               onChange={(newDate) => {
                 if (!newDate) return;
-                const dateUTC = dayjs.utc(newDate);
-                setEndDate(dateUTC);
-                if (format === DATE_TIME_ZONE_FORMAT && endTime) {
-                  // Merge date and time
-                  const merged = dateUTC
-                    .hour(endTime.hour())
-                    .minute(endTime.minute())
-                    .second(endTime.second());
-                  setEndDate(merged);
-                  onChange({
-                    start: startDate ? startDate.format(format) : "",
-                    end: merged.format(format),
-                  });
-                } else {
-                  onChange({
-                    start: startDate ? startDate.format(format) : "",
-                    end: dateUTC.format(format),
-                  });
+
+                if (newDate.format(format) !== "Invalid Date") {
+                  const dateUTC = dayjs.utc(newDate);
+                  setEndDate(dateUTC);
+                  if (format === DATE_TIME_ZONE_FORMAT && endTime) {
+                    // Merge date and time
+                    const merged = dateUTC
+                      .hour(endTime.hour())
+                      .minute(endTime.minute())
+                      .second(endTime.second());
+                    setEndDate(merged);
+                    onChange({
+                      start: startDate ? startDate.format(format) : "",
+                      end: merged.format(format),
+                    });
+                  } else {
+                    onChange({
+                      start: startDate ? startDate.format(format) : "",
+                      end: dateUTC.format(format),
+                    });
+                  }
                 }
               }}
               onBlur={() => {}}


### PR DESCRIPTION
add an invalid date check into the period component to prevent crashing while typing directly into the date field

## MADiE PR

Jira Ticket: [MAT-9321](https://jira.cms.gov/browse/MAT-9321)
(Optional) Related Tickets:

### Summary
Added a check for invalid date to prevent incomplete/invalid date object from being set onto the formik state.
<img width="500" height="110" alt="image" src="https://github.com/user-attachments/assets/43bfb7d1-e859-47d3-b8c1-968bd413fc4d" />


### All Submissions
* [x] This PR has the JIRA linked.
* [x] Required tests are included.
* [x] No extemporaneous files are included (i.e Complied files or testing results).
* [x] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).
* [ ] All CDN/Web dependencies are hosted internally (i.e MADiE-Root Repo).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
