### PR TITLE
MAT-9405: Add read only support for several TC Builder components.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@lhncbc/ucum-lhc": "^4.1.5",
         "@madie/cql-antlr-parser": "^1.0.11",
         "@madie/madie-auth": "^0.0.1",
-        "@madie/madie-design-system": "^1.2.81",
+        "@madie/madie-design-system": "^1.2.83",
         "@madie/madie-editor": "^0.0.1",
         "@madie/madie-models": "^1.4.54",
         "@madie/madie-root": "^0.0.3",
@@ -4473,9 +4473,9 @@
       }
     },
     "node_modules/@madie/madie-design-system": {
-      "version": "1.2.82",
-      "resolved": "https://registry.npmjs.org/@madie/madie-design-system/-/madie-design-system-1.2.82.tgz",
-      "integrity": "sha512-n0PkJbBSkEvD/utQLt7VBka85HJNtsowLi5sga9aY/SNDdtH5nXmAB3eXDp/A9WG4aJ2k4eLVygNW+sZUEQU6g==",
+      "version": "1.2.83",
+      "resolved": "https://registry.npmjs.org/@madie/madie-design-system/-/madie-design-system-1.2.83.tgz",
+      "integrity": "sha512-rweoMASseE27iNSzfi2M1oN5PPvlxa+5r0LJ3MqtMPDa3/EqeR93hyOx1u+eVbq8+mSgBys3kK0BKCjKnrbjcg==",
       "license": "CC0-1.0",
       "dependencies": {
         "@cmsgov/design-system": "^5.0.2",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "@lhncbc/ucum-lhc": "^4.1.5",
     "@madie/cql-antlr-parser": "^1.0.11",
     "@madie/madie-auth": "^0.0.1",
-    "@madie/madie-design-system": "^1.2.81",
+    "@madie/madie-design-system": "^1.2.83",
     "@madie/madie-editor": "^0.0.1",
     "@madie/madie-models": "^1.4.54",
     "@madie/madie-root": "^0.0.3",

--- a/src/components/editMeasure/testCases/api/fhirDefinitionServiceUtilities.test.tsx
+++ b/src/components/editMeasure/testCases/api/fhirDefinitionServiceUtilities.test.tsx
@@ -46,6 +46,19 @@ describe("FhirDefinitionServiceUtilities", () => {
             min: 0,
             type: [{ code: "string" }],
           },
+          {
+            path: "Patient.extension",
+            id: "Patient.extension:race",
+            min: 0,
+            type: [
+              {
+                code: "Extension",
+                profile: [
+                  "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race",
+                ],
+              },
+            ],
+          },
         ],
       },
     },
@@ -57,7 +70,7 @@ describe("FhirDefinitionServiceUtilities", () => {
       expect(result).toBe("Patient");
     });
 
-    it("Should remove indeces from path", () => {
+    it("Should remove indices from path", () => {
       const result = removeIndicesFromPath("Patient.name[0]");
       expect(result).toBe("Patient.name");
     });
@@ -80,6 +93,19 @@ describe("FhirDefinitionServiceUtilities", () => {
       // Elements should now be sorted alphabetically and include all elements
       expect(result).toEqual([
         { path: "Patient.age", min: 1, type: [{ code: "integer" }] },
+        {
+          path: "Patient.extension",
+          id: "Patient.extension:race",
+          min: 0,
+          type: [
+            {
+              code: "Extension",
+              profile: [
+                "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race",
+              ],
+            },
+          ],
+        },
         {
           path: "Patient.multipleBirth[x]",
           min: 1,
@@ -123,6 +149,19 @@ describe("FhirDefinitionServiceUtilities", () => {
         { path: "Patient.name", min: 0, type: [{ code: "HumanName" }] },
         { path: "Patient.age", min: 1, type: [{ code: "integer" }] },
         { path: "Patient.address.street", min: 0, type: [{ code: "string" }] },
+        {
+          path: "Patient.extension",
+          id: "Patient.extension:race",
+          min: 0,
+          type: [
+            {
+              code: "Extension",
+              profile: [
+                "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race",
+              ],
+            },
+          ],
+        },
       ]);
     });
 

--- a/src/components/editMeasure/testCases/api/fhirDefinitionServiceUtilities.tsx
+++ b/src/components/editMeasure/testCases/api/fhirDefinitionServiceUtilities.tsx
@@ -314,24 +314,24 @@ export function getTopLevelElements(resource: any) {
   const basePath = resource?.definition?.type;
   const elementsFiltered = elements?.filter(
     (e) =>
-      e.path.split(".")?.length === 2 &&
-      e.id !== "Extension.extension" &&
-      e.id !== "Patient.extension" &&
-      e.max !== "0" &&
-      // Exclude entries where the path contains these attributes or matches these element names
-      ![
-        ".contained",
-        ".text",
-        ".meta",
-        ".language",
-        ".implicitRules",
-        "modifierExtension",
-        "extension",
-      ].some(
-        (attribute) =>
-          e?.path?.includes(attribute) ||
-          e.path.substring(basePath?.length + 1) === attribute
-      )
+      (e.path.split(".")?.length === 2 &&
+        e.id !== "Extension.extension" &&
+        e.id !== "Patient.extension" &&
+        e.max !== "0" &&
+        // Exclude entries where the path contains these attributes or matches these element names
+        ![
+          ".contained",
+          ".text",
+          ".meta",
+          ".language",
+          ".implicitRules",
+          "modifierExtension",
+        ].some(
+          (attribute) =>
+            e?.path?.includes(attribute) ||
+            e.path.substring(basePath?.length + 1) === attribute
+        )) ||
+      (e?.path?.includes("extension") && e?.id.includes(":"))
   );
   //for each elementsFiltered, if type contains more than one type, duplicate the element and restrict the type to only that type
 

--- a/src/components/editMeasure/testCases/components/editTestCase/qiCore/LeftPanel/ElementsTab/builder/element/TypeEditor.tsx
+++ b/src/components/editMeasure/testCases/components/editTestCase/qiCore/LeftPanel/ElementsTab/builder/element/TypeEditor.tsx
@@ -870,7 +870,7 @@ const TypeEditor = ({
               {...formik.getFieldProps(label)}
               onChange={() => {}}
               formikHandleChange={formik.handleChange}
-              // Being depcreated for a formik handleChange
+              // Being deprecated for a formik handleChange
               // label={label} // label will be needed later to hook up to formik.
               fhirResource={resource}
               elementDefinition={structureDefinition} // id is patient.identifier[0].extension    ;

--- a/src/components/editMeasure/testCases/components/editTestCase/qiCore/LeftPanel/ElementsTab/builder/element/types/DateComponent.tsx
+++ b/src/components/editMeasure/testCases/components/editTestCase/qiCore/LeftPanel/ElementsTab/builder/element/types/DateComponent.tsx
@@ -86,7 +86,11 @@ const DateTimeComponent = ({
       setDate(null);
     }
   }, [value]);
-
+  // When the Select switches to readOnly, prevent the resulting ReadOnlyTextField's style from being overwritten
+  const selectProps: any = {};
+  if (canEdit) {
+    selectProps.style = { height: "38.125px", marginBottom: "2px" };
+  }
   return (
     <div className="element-editor-add-row">
       <Box sx={{ display: "flex", flexDirection: "column" }}>
@@ -105,7 +109,6 @@ const DateTimeComponent = ({
           >
             {/* select a format and render a picker */}
             <Select
-              style={{ height: "38.125px", marginBottim: "2px" }}
               required={fieldRequired}
               id={`date-format-selector-${label}`}
               label="Date Precision Level"
@@ -138,6 +141,7 @@ const DateTimeComponent = ({
               }}
               placeHolder={{ name: "Select Format", value: "" }}
               value={format ? format : ""}
+              {...selectProps}
             ></Select>
             <div
               onPaste={(e) => {
@@ -156,6 +160,7 @@ const DateTimeComponent = ({
                 helperText={helperText}
                 placeholder={format ? formatOptionRenderMap[format] : ""}
                 required={fieldRequired}
+                readOnly={!canEdit}
                 error={error}
                 value={date ? dayjs(date) : null}
                 views={format ? formatMap[format] : ["year"]}

--- a/src/components/editMeasure/testCases/components/editTestCase/qiCore/LeftPanel/ElementsTab/builder/element/types/DateField.tsx
+++ b/src/components/editMeasure/testCases/components/editTestCase/qiCore/LeftPanel/ElementsTab/builder/element/types/DateField.tsx
@@ -1,6 +1,9 @@
 import React, { useRef, useState } from "react";
 import PropTypes from "prop-types";
-import { TextField } from "@madie/madie-design-system/dist/react";
+import {
+  ReadOnlyTextField,
+  TextField,
+} from "@madie/madie-design-system/dist/react";
 import { Box } from "@mui/material";
 import { DatePicker } from "@mui/x-date-pickers/DatePicker";
 import dayjs from "dayjs";
@@ -45,6 +48,7 @@ const DateField = ({
   label,
   value,
   disabled,
+  readOnly = false,
   error,
   helperText,
   required = false,
@@ -65,41 +69,53 @@ const DateField = ({
   })(format);
   return (
     <Box sx={{ ...containerSx }}>
-      <DatePicker
-        emptyLabel="custom label"
-        value={value}
-        onChange={onChange}
-        views={views}
-        disabled={disabled}
-        onClose={() => rest?.onBlur()}
-        // need this to false to prevent MUI from adding their own format masking that conflicts with ours
-        disableMaskedInput={false}
-        // i only want to apply format if updatedFormat is not undefined
-        format={updatedFormat ? updatedFormat : undefined}
-        slotProps={{
-          textField: (params) => {
-            const { InputProps } = params;
-            InputProps["data-testid"] = id;
-            InputProps["aria-required"] = required;
-            return {
-              id: id,
-              label,
-              sx: { ...dateTextFieldStyle, ...textFieldSx },
-              placeholder,
-              error: error,
-              helperText: helperText,
-              onBlur: rest?.onBlur,
-            };
-          },
-          openPickerButton: {
-            id: `${id}-open-picker-button`,
-            //@ts-ignore
-            dataTestId: `${id}-open-picker-button`,
-          },
-        }}
-        slots={{ textField: TextField }}
-        {...rest}
-      />
+      {readOnly ? (
+        <ReadOnlyTextField
+          required={required}
+          label={label}
+          id={id}
+          size="small"
+          data-testid={id}
+          {...rest}
+          value={value ? dayjs.utc(value).format(updatedFormat) : "-"}
+        />
+      ) : (
+        <DatePicker
+          emptyLabel="custom label"
+          value={value}
+          onChange={onChange}
+          views={views}
+          disabled={disabled}
+          onClose={() => rest?.onBlur()}
+          // need this to false to prevent MUI from adding their own format masking that conflicts with ours
+          disableMaskedInput={false}
+          // Only apply format if updatedFormat is not undefined
+          format={updatedFormat ? updatedFormat : undefined}
+          slotProps={{
+            textField: (params) => {
+              const { InputProps } = params;
+              InputProps["data-testid"] = id;
+              InputProps["aria-required"] = required;
+              return {
+                id: id,
+                label,
+                sx: { ...dateTextFieldStyle, ...textFieldSx },
+                placeholder,
+                error: error,
+                helperText: helperText,
+                onBlur: rest?.onBlur,
+              };
+            },
+            openPickerButton: {
+              id: `${id}-open-picker-button`,
+              //@ts-ignore
+              dataTestId: `${id}-open-picker-button`,
+            },
+          }}
+          slots={{ textField: TextField }}
+          {...rest}
+        />
+      )}
     </Box>
   );
 };

--- a/src/components/editMeasure/testCases/components/editTestCase/qiCore/LeftPanel/ElementsTab/builder/element/types/DateTimeComponent.tsx
+++ b/src/components/editMeasure/testCases/components/editTestCase/qiCore/LeftPanel/ElementsTab/builder/element/types/DateTimeComponent.tsx
@@ -135,7 +135,11 @@ const DateTimeComponent = ({
       setDate(null);
     }
   }, [value]);
-
+  // When the Select switches to readOnly, prevent the resulting ReadOnlyTextField's style from being overwritten
+  const selectProps: any = {};
+  if (canEdit) {
+    selectProps.style = { height: "38.125px", marginBottom: "2px" };
+  }
   return (
     <div className="element-editor-add-row">
       <Box sx={{ display: "flex", flexDirection: "column" }}>
@@ -155,7 +159,6 @@ const DateTimeComponent = ({
             {/* select a format and render a picker */}
             <div>
               <Select
-                style={{ height: "38.125px", marginBottom: "2px" }}
                 required={fieldRequired}
                 id={`date-time-format-selector-${label}`}
                 label="Date Precision Level"
@@ -188,6 +191,7 @@ const DateTimeComponent = ({
                 }}
                 placeHolder={{ name: "Select Format", value: "" }}
                 value={format ? format : ""}
+                {...selectProps}
               ></Select>
             </div>
 
@@ -210,6 +214,7 @@ const DateTimeComponent = ({
                 value={date}
                 views={format ? formatMap[format] : ["year"]}
                 disabled={!canEdit || !format || format === "Invalid Format"}
+                readOnly={!canEdit}
                 format={format}
                 placeholder={format ? formatOptionRenderMap[format] : ""}
                 id={`${format || "year"}-field-${label}`}

--- a/src/components/editMeasure/testCases/components/editTestCase/qiCore/LeftPanel/ElementsTab/builder/element/types/ExtensionComponent.test.tsx
+++ b/src/components/editMeasure/testCases/components/editTestCase/qiCore/LeftPanel/ElementsTab/builder/element/types/ExtensionComponent.test.tsx
@@ -3,20 +3,18 @@ import { render, screen } from "@testing-library/react";
 import ExtensionComponent from "./ExtensionComponent";
 
 describe("ExtensionComponent", () => {
-  describe("ExtensionComponent", () => {
-    test("Should render ExtensionComponent with add button", () => {
-      render(
-        <ExtensionComponent
-          label={"test"}
-          canEdit={true}
-          elementDefinition={{}}
-          parentStructureDefinition={{}}
-          showAddAttributeButton={true}
-          addTitle={"Extension"}
-        />
-      );
+  test("Should render ExtensionComponent with add button", () => {
+    render(
+      <ExtensionComponent
+        label={"test"}
+        canEdit={true}
+        elementDefinition={{}}
+        parentStructureDefinition={{}}
+        showAddAttributeButton={true}
+        addTitle={"Extension"}
+      />
+    );
 
-      expect(screen.getByText("Add Extension")).toBeInTheDocument();
-    });
+    expect(screen.getByText("Add Extension")).toBeInTheDocument();
   });
 });

--- a/src/components/editMeasure/testCases/components/editTestCase/qiCore/LeftPanel/ElementsTab/builder/element/types/ExtensionComponent.tsx
+++ b/src/components/editMeasure/testCases/components/editTestCase/qiCore/LeftPanel/ElementsTab/builder/element/types/ExtensionComponent.tsx
@@ -67,7 +67,7 @@ const ExtensionComponent = ({
     elementDefinition?.id
   ); // get reference from SD.snap
 
-  // TODO: modify this from a use effect later. Currently we haven't found and multiple cohice choicetypes to test the change.
+  // TODO: modify this from a use effect later. Currently we haven't found and multiple choice choicetypes to test the change.
   useEffect(() => {
     if (valueElement) {
       setSelectedValueType(valueElement.type[0].code);
@@ -103,7 +103,7 @@ const ExtensionComponent = ({
             SelectDisplayProps={{
               "aria-required": "true",
             }}
-            readOnly={false}
+            readOnly={true}
             required={valueElement?.min > 0}
             options={[
               <MenuItem
@@ -138,7 +138,7 @@ const ExtensionComponent = ({
       <div data-testid={idPrefix}>
         <div className="element-editor-add-row">
           <UriComponent
-            canEdit={!urlElement?.fixedUri} // disable if this is fixed value
+            canEdit={canEdit}
             fieldRequired={urlElement?.min > 0}
             label={`${elementDefinition.id}.url`}
             structureDefinition={null}
@@ -151,6 +151,7 @@ const ExtensionComponent = ({
         </div>
         <Select
           label={`${elementDefinition.id}.value[x]`}
+          readOnly={!canEdit}
           inputProps={{
             "data-testid": `${idPrefix}-type-selector-input`,
           }}

--- a/src/components/editMeasure/testCases/components/editTestCase/qiCore/LeftPanel/ElementsTab/builder/element/types/PeriodDateTimeComponent.test.tsx
+++ b/src/components/editMeasure/testCases/components/editTestCase/qiCore/LeftPanel/ElementsTab/builder/element/types/PeriodDateTimeComponent.test.tsx
@@ -403,4 +403,42 @@ describe("PeriodDateTimeComponent useEffect", () => {
     );
     expect((selector as HTMLSelectElement).value).toBe("YYYY-MM-DD");
   });
+
+  test("renders in read-only mode when canEdit is false", async () => {
+    render(
+      <PeriodDateTimeComponent
+        canEdit={false}
+        fieldRequired={false}
+        value={{
+          start: "2024-09-26T12:00:00+00:00",
+          end: "2024-09-27T14:00:00+00:00",
+        }}
+        onChange={jest.fn()}
+      />
+    );
+
+    // Verify that the date format selector is read-only
+    const formatSelector = await screen.findByTestId(
+      `date-time-format-selector-field-DateTime`
+    );
+    expect(formatSelector).toHaveAttribute("readonly");
+
+    // Verify that the start and end date fields are read-only
+    const startDateField = await screen.findByTestId(
+      "start-YYYY-MM-DDTHH:mm:ssZ-field-DateTime"
+    );
+    const endDateField = await screen.findByTestId(
+      "end-YYYY-MM-DDTHH:mm:ssZ-field-DateTime"
+    );
+    expect(startDateField).toHaveAttribute("readonly");
+    expect(endDateField).toHaveAttribute("readonly");
+
+    // Verify that time fields are also read-only
+    const startTimeInput = await screen.findByTestId(
+      "start-time-field-DateTime"
+    );
+    const endTimeInput = await screen.findByTestId("end-time-field-DateTime");
+    expect(startTimeInput).toHaveAttribute("readonly");
+    expect(endTimeInput).toHaveAttribute("readonly");
+  });
 });

--- a/src/components/editMeasure/testCases/components/editTestCase/qiCore/LeftPanel/ElementsTab/builder/element/types/PeriodDateTimeComponent.tsx
+++ b/src/components/editMeasure/testCases/components/editTestCase/qiCore/LeftPanel/ElementsTab/builder/element/types/PeriodDateTimeComponent.tsx
@@ -8,7 +8,11 @@ import timezone from "dayjs/plugin/timezone";
 import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc";
 import advancedFormat from "dayjs/plugin/advancedFormat";
-import { Select, TimeField } from "@madie/madie-design-system/dist/react";
+import {
+  Select,
+  TimeField,
+  ReadOnlyTextField,
+} from "@madie/madie-design-system/dist/react";
 import DateField from "./DateField";
 import { formatOptionRenderMap } from "./DateTimeComponent";
 
@@ -133,12 +137,16 @@ const PeriodDateTimeComponent = ({
 
     setUserSelectedFormat(false);
   }, [value]);
-
+  // When the Select switches to readOnly, prevent the resulting ReadOnlyTextField's style from being overwritten
+  const selectProps: any = {};
+  if (canEdit) {
+    selectProps.style = { height: "38.125px", marginBottom: "2px" };
+  }
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
       <div style={{ marginBottom: "16px", maxWidth: 220 }}>
         <Select
-          style={{ height: "38.125px", marginBottom: "2px" }}
+          readOnly={!canEdit}
           required={fieldRequired}
           id={`date-time-format-selector-${label}`}
           label="Date Precision Level"
@@ -147,7 +155,6 @@ const PeriodDateTimeComponent = ({
             "aria-describedby": `date-time-format-selector-input-field-helper-text-${label}`,
           }}
           data-testid={`date-time-format-selector-field-${label}`}
-          readOnly={!canEdit}
           SelectDisplayProps={{
             "aria-required": "true",
           }}
@@ -167,6 +174,7 @@ const PeriodDateTimeComponent = ({
           }}
           placeHolder={{ name: "Select Format", value: "" }}
           value={format ? format : ""}
+          {...selectProps}
         />
       </div>
 
@@ -198,6 +206,7 @@ const PeriodDateTimeComponent = ({
             <DateField
               label="Start Date"
               format={format}
+              readOnly={!canEdit}
               required={fieldRequired}
               error={error.start}
               helperText={helperText.start}
@@ -233,33 +242,48 @@ const PeriodDateTimeComponent = ({
               }}
               onBlur={() => {}}
             />
-            {format === DATE_TIME_ZONE_FORMAT && (
-              <TimeField
-                disabled={!canEdit || !startDate}
-                required={fieldRequired}
-                label="Start Time"
-                id={`start-time-field-${label}`}
-                seconds
-                views={["hours", "minutes", "seconds"]}
-                data-testid="start-time-input"
-                handleTimeChange={(time) => {
-                  if (!startDate) return;
-                  const utcTime = dayjs.utc(time);
-                  setStartTime(utcTime);
-                  // Merge date and time
-                  const merged = startDate
-                    .hour(utcTime.hour())
-                    .minute(utcTime.minute())
-                    .second(utcTime.second());
-                  setStartDate(merged);
-                  onChange({
-                    start: merged.format(format),
-                    end: endDate ? endDate.format(format) : "",
-                  });
-                }}
-                value={startTime || startDate}
-              />
-            )}
+            {format === DATE_TIME_ZONE_FORMAT &&
+              (canEdit ? (
+                <TimeField
+                  disabled={!canEdit || !startDate}
+                  readOnly={!canEdit}
+                  required={fieldRequired}
+                  label="Start Time"
+                  id={`start-time-field-${label}`}
+                  seconds
+                  views={["hours", "minutes", "seconds"]}
+                  data-testid="start-time-input"
+                  handleTimeChange={(time) => {
+                    if (!startDate) return;
+                    const utcTime = dayjs.utc(time);
+                    setStartTime(utcTime);
+                    // Merge date and time
+                    const merged = startDate
+                      .hour(utcTime.hour())
+                      .minute(utcTime.minute())
+                      .second(utcTime.second());
+                    setStartDate(merged);
+                    onChange({
+                      start: merged.format(format),
+                      end: endDate ? endDate.format(format) : "",
+                    });
+                  }}
+                  value={startTime || startDate}
+                />
+              ) : (
+                <ReadOnlyTextField
+                  required={fieldRequired}
+                  label={label}
+                  id={`start-time-field-${label}`}
+                  data-testid={`start-time-field-${label}`}
+                  size="small"
+                  value={
+                    startTime || startDate
+                      ? (startTime || startDate).format("HH:mm:ss a")
+                      : "-"
+                  }
+                />
+              ))}
           </div>
           <span style={{ alignSelf: "center", padding: "0 8px" }}>To</span>
           <div
@@ -281,6 +305,7 @@ const PeriodDateTimeComponent = ({
               label="End Date"
               format={format}
               required={fieldRequired}
+              readOnly={!canEdit}
               error={error.end}
               helperText={helperText.end}
               value={endDate}
@@ -315,33 +340,47 @@ const PeriodDateTimeComponent = ({
               }}
               onBlur={() => {}}
             />
-            {format === DATE_TIME_ZONE_FORMAT && (
-              <TimeField
-                disabled={!canEdit || !endDate}
-                required={fieldRequired}
-                label="End Time"
-                id={`end-time-field-${label}`}
-                seconds
-                views={["hours", "minutes", "seconds"]}
-                data-testid="end-time-input"
-                handleTimeChange={(time) => {
-                  if (!endDate) return;
-                  const utcTime = dayjs.utc(time);
-                  setEndTime(utcTime);
-                  // Merge date and time
-                  const merged = endDate
-                    .hour(utcTime.hour())
-                    .minute(utcTime.minute())
-                    .second(utcTime.second());
-                  setEndDate(merged);
-                  onChange({
-                    start: startDate ? startDate.format(format) : "",
-                    end: merged.format(format),
-                  });
-                }}
-                value={endTime || endDate}
-              />
-            )}
+            {format === DATE_TIME_ZONE_FORMAT &&
+              (canEdit ? (
+                <TimeField
+                  disabled={!canEdit || !endDate}
+                  required={fieldRequired}
+                  label="End Time"
+                  id={`end-time-field-${label}`}
+                  seconds
+                  views={["hours", "minutes", "seconds"]}
+                  data-testid="end-time-input"
+                  handleTimeChange={(time) => {
+                    if (!endDate) return;
+                    const utcTime = dayjs.utc(time);
+                    setEndTime(utcTime);
+                    // Merge date and time
+                    const merged = endDate
+                      .hour(utcTime.hour())
+                      .minute(utcTime.minute())
+                      .second(utcTime.second());
+                    setEndDate(merged);
+                    onChange({
+                      start: startDate ? startDate.format(format) : "",
+                      end: merged.format(format),
+                    });
+                  }}
+                  value={endTime || endDate}
+                />
+              ) : (
+                <ReadOnlyTextField
+                  required={fieldRequired}
+                  label={label}
+                  id={`end-time-field-${label}`}
+                  data-testid={`end-time-field-${label}`}
+                  size="small"
+                  value={
+                    endTime || endDate
+                      ? (endTime || endDate).format("HH:mm:ss a")
+                      : "-"
+                  }
+                />
+              ))}
           </div>
         </div>
       </LocalizationProvider>

--- a/src/components/editMeasure/testCases/components/editTestCase/qiCore/LeftPanel/ElementsTab/builder/element/types/ReferenceComponent.tsx
+++ b/src/components/editMeasure/testCases/components/editTestCase/qiCore/LeftPanel/ElementsTab/builder/element/types/ReferenceComponent.tsx
@@ -121,6 +121,7 @@ export default function ReferenceComponent({
             id: `reference-type-input-select`,
             required: required,
           }}
+          readOnly={!canEdit}
           options={resourceProfileOptions.map((opt, i) => (
             <MenuItem
               key={`${opt.label}-${opt.profile}-${i}`}
@@ -178,6 +179,7 @@ export default function ReferenceComponent({
               id: `reference-select-input`,
               required: required,
             }}
+            readOnly={!canEdit}
             options={finalOptions.map((opt, i) => (
               <MenuItem
                 key={`${opt.label}-${opt.value}-${i}`}


### PR DESCRIPTION
## MADiE PR

Jira Ticket: [MAT-9405](https://jira.cms.gov/browse/MAT-9405)
(Optional) Related Tickets:

### Summary

1. Include Profiled extensions in the Builder. Exclude all other extensions.
2. Apply read only state when user cannot edit the TC. Dynamic application of styling to avoid overwriting the read-only styling in the design-system.
    1. DateComponent
    2. DateTimeComponent
    3. PeriodDateTimeComponent
3. Apply read only state with user selected date format.
    1. DateField
4. Apply read only state when user cannot edit TC.
    1. ExtensionComponent
    2. ReferenceComponent

### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included.
* [ ] No extemporaneous files are included (i.e Complied files or testing results).
* [ ] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).
* [ ] All CDN/Web dependencies are hosted internally (i.e MADiE-Root Repo).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
