### PR TITLE
MAT-9539 Render Top Level Content Reference types

### DIFF
--- a/src/components/editMeasure/testCases/components/editTestCase/qiCore/LeftPanel/ElementsTab/builder/element/TypeEditor.test.tsx
+++ b/src/components/editMeasure/testCases/components/editTestCase/qiCore/LeftPanel/ElementsTab/builder/element/TypeEditor.test.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { render, screen, act, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
-import TypeEditor, { getContentReferenceType } from "./TypeEditor";
+import TypeEditor from "./TypeEditor";
 import useFhirDefinitionsServiceApi, {
   FhirDefinitionsServiceApi,
 } from "../../../../../../../api/useFhirDefinitionsService";
@@ -4280,70 +4280,5 @@ describe("TypeEditor Component", () => {
     expect(screen.queryByText("Item")).toBeInTheDocument();
     // Restore the original mock
     jest.restoreAllMocks();
-  });
-});
-
-describe("getContentReferenceType utility function", () => {
-  it("returns null when refUrl is null", () => {
-    const result = getContentReferenceType(null, []);
-    expect(result).toBeNull();
-  });
-
-  it("returns null when refUrl is undefined", () => {
-    const result = getContentReferenceType(undefined, []);
-    expect(result).toBeNull();
-  });
-
-  it("returns null when refUrl is empty string", () => {
-    const result = getContentReferenceType("", []);
-    expect(result).toBeNull();
-  });
-
-  it("returns null when refUrl has no hash fragment", () => {
-    const formInfo = [
-      ["QuestionnaireResponse.item", { type: [{ code: "BackboneElement" }] }],
-    ];
-    const result = getContentReferenceType("invalidReference", formInfo);
-    expect(result).toBeNull();
-  });
-
-  it("returns null when contentReference is not found in formInfo", () => {
-    const formInfo = [
-      ["QuestionnaireResponse.item", { type: [{ code: "BackboneElement" }] }],
-    ];
-    const result = getContentReferenceType(
-      "#QuestionnaireResponse.notFound",
-      formInfo
-    );
-    expect(result).toBeNull();
-  });
-
-  it("returns type code when valid contentReference is found", () => {
-    const formInfo = [
-      ["QuestionnaireResponse.item", { type: [{ code: "BackboneElement" }] }],
-    ];
-    const result = getContentReferenceType(
-      "#QuestionnaireResponse.item",
-      formInfo
-    );
-    expect(result).toBe("BackboneElement");
-  });
-
-  it("returns null when formInfo entry has no type array", () => {
-    const formInfo = [["QuestionnaireResponse.item", {}]];
-    const result = getContentReferenceType(
-      "#QuestionnaireResponse.item",
-      formInfo
-    );
-    expect(result).toBeUndefined();
-  });
-
-  it("returns null when formInfo entry type array is empty", () => {
-    const formInfo = [["QuestionnaireResponse.item", { type: [] }]];
-    const result = getContentReferenceType(
-      "#QuestionnaireResponse.item",
-      formInfo
-    );
-    expect(result).toBeUndefined();
   });
 });

--- a/src/components/editMeasure/testCases/components/editTestCase/qiCore/LeftPanel/ElementsTab/builder/element/TypeEditor.test.tsx
+++ b/src/components/editMeasure/testCases/components/editTestCase/qiCore/LeftPanel/ElementsTab/builder/element/TypeEditor.test.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { render, screen, act, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
-import TypeEditor from "./TypeEditor";
+import TypeEditor, { getContentReferenceType } from "./TypeEditor";
 import useFhirDefinitionsServiceApi, {
   FhirDefinitionsServiceApi,
 } from "../../../../../../../api/useFhirDefinitionsService";
@@ -4154,6 +4154,73 @@ describe("TypeEditor Component", () => {
     expect(inputDate).toBeInTheDocument();
   });
 
+  test("Should render first level ContentReferenceType attribute", () => {
+    const adjudicationElementDef = {
+      id: "ClaimResponse.adjudication",
+      type: [],
+      max: "*",
+      min: 0,
+      canBeMultipleCardinality: true,
+      contentReference: "#ClaimResponse.item.adjudication",
+    };
+    const mockFormInfo = [
+      ["ClaimResponse.adjudication", adjudicationElementDef],
+      [
+        "ClaimResponse.item.adjudication",
+        {
+          id: "ClaimResponse.item.adjudication",
+          type: [{ code: "BackboneElement" }],
+          max: "1",
+          min: 1,
+          canBeMultipleCardinality: false,
+        },
+      ],
+      [
+        "ClaimResponse.item.adjudication.category",
+        {
+          id: "ClaimResponse.item.adjudication.category",
+          type: [{ code: "CodeableConcept" }],
+          max: "1",
+          min: 1,
+          canBeMultipleCardinality: false,
+        },
+      ],
+      [
+        "ClaimResponse.item.adjudication.reason",
+        {
+          id: "ClaimResponse.item.adjudication.reason",
+          type: [{ code: "CodeableConcept" }],
+          max: "1",
+          min: 0,
+          canBeMultipleCardinality: false,
+        },
+      ],
+    ];
+    // Override the global mock to return false for this test
+    const fhirUtils = require("../../../../../../../api/fhirDefinitionServiceUtilities");
+    jest.spyOn(fhirUtils, "isComponentDataType").mockReturnValue(false);
+
+    render(
+      <FormikProvider value={mockFormik}>
+        <RequiredFieldsProvider requiredFields={{}} formInfo={mockFormInfo}>
+          <TypeEditor
+            resource={{ resourceType: "ClaimResponse" }}
+            structureDefinition={adjudicationElementDef}
+            label="ClaimResponse.adjudication"
+            canEdit={true}
+            parentStructureDefinition={null}
+          />
+        </RequiredFieldsProvider>
+      </FormikProvider>
+    );
+
+    // "Category" and "Reason" elements from the referenced definition must be rendered
+    expect(screen.queryByText("Category")).toBeInTheDocument();
+    expect(screen.queryByText("Reason")).toBeInTheDocument();
+    // Restore the original mock
+    jest.restoreAllMocks();
+  });
+
   test("Should render ContentReferenceType when childDef has contentReference", () => {
     const mockFormInfo = [
       [
@@ -4213,5 +4280,70 @@ describe("TypeEditor Component", () => {
     expect(screen.queryByText("Item")).toBeInTheDocument();
     // Restore the original mock
     jest.restoreAllMocks();
+  });
+});
+
+describe("getContentReferenceType utility function", () => {
+  it("returns null when refUrl is null", () => {
+    const result = getContentReferenceType(null, []);
+    expect(result).toBeNull();
+  });
+
+  it("returns null when refUrl is undefined", () => {
+    const result = getContentReferenceType(undefined, []);
+    expect(result).toBeNull();
+  });
+
+  it("returns null when refUrl is empty string", () => {
+    const result = getContentReferenceType("", []);
+    expect(result).toBeNull();
+  });
+
+  it("returns null when refUrl has no hash fragment", () => {
+    const formInfo = [
+      ["QuestionnaireResponse.item", { type: [{ code: "BackboneElement" }] }],
+    ];
+    const result = getContentReferenceType("invalidReference", formInfo);
+    expect(result).toBeNull();
+  });
+
+  it("returns null when contentReference is not found in formInfo", () => {
+    const formInfo = [
+      ["QuestionnaireResponse.item", { type: [{ code: "BackboneElement" }] }],
+    ];
+    const result = getContentReferenceType(
+      "#QuestionnaireResponse.notFound",
+      formInfo
+    );
+    expect(result).toBeNull();
+  });
+
+  it("returns type code when valid contentReference is found", () => {
+    const formInfo = [
+      ["QuestionnaireResponse.item", { type: [{ code: "BackboneElement" }] }],
+    ];
+    const result = getContentReferenceType(
+      "#QuestionnaireResponse.item",
+      formInfo
+    );
+    expect(result).toBe("BackboneElement");
+  });
+
+  it("returns null when formInfo entry has no type array", () => {
+    const formInfo = [["QuestionnaireResponse.item", {}]];
+    const result = getContentReferenceType(
+      "#QuestionnaireResponse.item",
+      formInfo
+    );
+    expect(result).toBeUndefined();
+  });
+
+  it("returns null when formInfo entry type array is empty", () => {
+    const formInfo = [["QuestionnaireResponse.item", { type: [] }]];
+    const result = getContentReferenceType(
+      "#QuestionnaireResponse.item",
+      formInfo
+    );
+    expect(result).toBeUndefined();
   });
 });

--- a/src/components/editMeasure/testCases/components/editTestCase/qiCore/LeftPanel/ElementsTab/builder/element/TypeEditor.tsx
+++ b/src/components/editMeasure/testCases/components/editTestCase/qiCore/LeftPanel/ElementsTab/builder/element/TypeEditor.tsx
@@ -49,6 +49,7 @@ export const formikErrorHandler = (name: string, formik) => {
 };
 
 const getContentReferencePath = (refUrl: string) => refUrl.split("#").pop();
+
 export const getContentReferenceType = (refUrl: string, formInfo: any) => {
   if (_.isNil(refUrl) || _.isEmpty(refUrl)) {
     return null;

--- a/src/components/editMeasure/testCases/components/editTestCase/qiCore/LeftPanel/ElementsTab/builder/element/TypeEditor.tsx
+++ b/src/components/editMeasure/testCases/components/editTestCase/qiCore/LeftPanel/ElementsTab/builder/element/TypeEditor.tsx
@@ -51,21 +51,6 @@ export const formikErrorHandler = (name: string, formik) => {
 const getContentReferencePath = (referenceUrl: string) =>
   referenceUrl.split("#").pop();
 
-export const getContentReferenceType = (
-  referenceUrl: string,
-  formInfo: any
-) => {
-  if (_.isNil(referenceUrl) || _.isEmpty(referenceUrl)) {
-    return null;
-  }
-  const referencePath = getContentReferencePath(referenceUrl);
-  const reference = formInfo.find(([key]) => key === referencePath);
-  if (reference) {
-    return reference[1].type?.[0]?.code;
-  }
-  return null;
-};
-
 // onChange is being deprecated as no updates to the resource are tracked.
 // Changes directly to the json should be done with a dispatch, this propagates downstream changes in formik.
 // any temporary form state should be done through formik.
@@ -81,19 +66,11 @@ const TypeEditor = ({
   let required = getRequired(requiredFields, stripAllIndexes(label));
   const fhirDefinitionsService = useRef(useFhirDefinitionsServiceApi());
 
-  let type: string;
-  if (structureDefinition?.contentReference) {
-    type = getContentReferenceType(
-      structureDefinition.contentReference,
-      formInfo
-    );
-  } else {
-    type = structureDefinition?.type?.find((t) =>
-      _.toLower(label).includes(_.toLower(t.code))
-    )?.code;
-    if (!type) {
-      type = structureDefinition?.type?.[0]?.code;
-    }
+  let type = structureDefinition?.type?.find((t) =>
+    _.toLower(label).includes(_.toLower(t.code))
+  )?.code;
+  if (!type) {
+    type = structureDefinition?.type?.[0]?.code;
   }
 
   const values = _.get(formik.values, label);

--- a/src/components/editMeasure/testCases/components/editTestCase/qiCore/LeftPanel/ElementsTab/builder/element/TypeEditor.tsx
+++ b/src/components/editMeasure/testCases/components/editTestCase/qiCore/LeftPanel/ElementsTab/builder/element/TypeEditor.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useMemo, useRef } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import * as _ from "lodash";
 import { Box, Divider } from "@mui/material";
 
@@ -16,15 +16,15 @@ import { useFormikContext } from "formik";
 import ExtensionComponent from "./types/ExtensionComponent";
 import useFhirDefinitionsServiceApi from "../../../../../../../api/useFhirDefinitionsService";
 import {
-  isComponentDataType,
-  stripAllIndexes,
-  getRequired,
-  getTopLevelElements,
+  formatAttributeLabel,
   getFirstChildren,
-  getNestedProperty,
   getIndexFromPath,
   getLastPart,
-  formatAttributeLabel,
+  getNestedProperty,
+  getRequired,
+  getTopLevelElements,
+  isComponentDataType,
+  stripAllIndexes,
 } from "../../../../../../../api/fhirDefinitionServiceUtilities";
 import CodingComponent from "./types/CodingComponent";
 import { useRequiredFields } from "./RequiredFieldsContext";
@@ -47,6 +47,20 @@ export const formikErrorHandler = (name: string, formik) => {
     return errors;
   }
 };
+
+const getContentReferencePath = (refUrl: string) => refUrl.split("#").pop();
+export const getContentReferenceType = (refUrl: string, formInfo: any) => {
+  if (_.isNil(refUrl) || _.isEmpty(refUrl)) {
+    return null;
+  }
+  const contentReference = getContentReferencePath(refUrl);
+  const reference = formInfo.find(([key]) => key === contentReference);
+  if (reference) {
+    return reference[1].type?.[0]?.code;
+  }
+  return null;
+};
+
 // onChange is being deprecated as no updates to the resource are tracked.
 // Changes directly to the json should be done with a dispatch, this propagates downstream changes in formik.
 // any temporary form state should be done through formik.
@@ -62,12 +76,21 @@ const TypeEditor = ({
   let required = getRequired(requiredFields, stripAllIndexes(label));
   const fhirDefinitionsService = useRef(useFhirDefinitionsServiceApi());
 
-  let type: string = structureDefinition?.type?.find((t) =>
-    _.toLower(label).includes(_.toLower(t.code))
-  )?.code;
-  if (!type) {
-    type = structureDefinition?.type?.[0]?.code;
+  let type: string;
+  if (structureDefinition?.contentReference) {
+    type = getContentReferenceType(
+      structureDefinition.contentReference,
+      formInfo
+    );
+  } else {
+    type = structureDefinition?.type?.find((t) =>
+      _.toLower(label).includes(_.toLower(t.code))
+    )?.code;
+    if (!type) {
+      type = structureDefinition?.type?.[0]?.code;
+    }
   }
+
   const values = _.get(formik.values, label);
   // is multiple cardinality?
   if (structureDefinition?.max === "*") {
@@ -90,18 +113,23 @@ const TypeEditor = ({
   // DiagnosticReport.presentedForm comes in without the index. We need to map it for multiple cardinality to test stuff.
   const childDefs = useMemo(() => {
     if (!isComponentDataType(type)) {
-      const elements = getFirstChildren(stripAllIndexes(label), formInfo);
+      let strippedLabel = stripAllIndexes(label);
+      if (structureDefinition?.contentReference) {
+        strippedLabel = getContentReferencePath(
+          structureDefinition.contentReference
+        );
+      }
+      const elements = getFirstChildren(strippedLabel, formInfo);
       if (elements?.length) {
-        const updatedElements = elements.map((el) => {
+        return elements.map((el) => {
           const lastPart = el.id.split(".").pop();
           const updatedId = `${label}.${lastPart}`;
           return { ...el, id: updatedId };
         });
-        return updatedElements; //previously filtered out type === BackboneElement
       }
     }
     return [];
-  }, [type, label, getFirstChildren]);
+  }, [type, label, structureDefinition, formInfo]);
 
   // Given structureDefinition.type[{ code: "sometype", profiles: ["strings", "of", "profiles"]}]
   // we need to look at the get use the profile list to get resource trees so we can render all the children in case Extension.

--- a/src/components/editMeasure/testCases/components/editTestCase/qiCore/LeftPanel/ElementsTab/builder/element/TypeEditor.tsx
+++ b/src/components/editMeasure/testCases/components/editTestCase/qiCore/LeftPanel/ElementsTab/builder/element/TypeEditor.tsx
@@ -48,14 +48,18 @@ export const formikErrorHandler = (name: string, formik) => {
   }
 };
 
-const getContentReferencePath = (refUrl: string) => refUrl.split("#").pop();
+const getContentReferencePath = (referenceUrl: string) =>
+  referenceUrl.split("#").pop();
 
-export const getContentReferenceType = (refUrl: string, formInfo: any) => {
-  if (_.isNil(refUrl) || _.isEmpty(refUrl)) {
+export const getContentReferenceType = (
+  referenceUrl: string,
+  formInfo: any
+) => {
+  if (_.isNil(referenceUrl) || _.isEmpty(referenceUrl)) {
     return null;
   }
-  const contentReference = getContentReferencePath(refUrl);
-  const reference = formInfo.find(([key]) => key === contentReference);
+  const referencePath = getContentReferencePath(referenceUrl);
+  const reference = formInfo.find(([key]) => key === referencePath);
   if (reference) {
     return reference[1].type?.[0]?.code;
   }


### PR DESCRIPTION
## MADiE PR

Jira Ticket: [MAT-9539](https://jira.cms.gov/browse/MAT-9539)
(Optional) Related Tickets:

### Summary
- Top level attribute that references other attributes were not rendered properly in some cases. e.g. `ClaimResponse.adjudication` does not have its own type. It gets its type from ClaimResponse.item.adjudication. This PR addresses rending of such attributes

### All Submissions
* [x] This PR has the JIRA linked.
* [x] Required tests are included.
* [x] No extemporaneous files are included (i.e Complied files or testing results).
* [x] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).
* [ ] All CDN/Web dependencies are hosted internally (i.e MADiE-Root Repo).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.

<img width="1261" height="946" alt="image" src="https://github.com/user-attachments/assets/5b584eb7-7a6d-4858-b36b-3a99a81b6819" />
