### PR TITLE
MAT-9511: Group Delete blocked by TC Lock when only single group. Also, QDM Group support.

### DIFF
--- a/src/components/editMeasure/populationCriteria/groups/QDM/QDMMeasureGroups.test.tsx
+++ b/src/components/editMeasure/populationCriteria/groups/QDM/QDMMeasureGroups.test.tsx
@@ -1216,7 +1216,6 @@ describe("Cohort Population Criteria validations", () => {
     expect(submitBtn).toBeDisabled();
   });
 
-  //temporarily skipping as 423 error is not being returned from mock api
   test("Should not be able to save if there is 423 error", async () => {
     jest.clearAllMocks();
     cohortMeasure.scoring = "Cohort";
@@ -1631,10 +1630,12 @@ describe("Delete Tests", () => {
       )
     );
 
-    expect(mockMeasureServiceApi.deleteMeasureGroup).toHaveBeenCalledWith(
-      "7p03-5r29-7O0I",
-      "test-measure"
-    );
+    await waitFor(() => {
+      expect(mockMeasureServiceApi.deleteMeasureGroup).toHaveBeenCalledWith(
+        "7p03-5r29-7O0I",
+        "test-measure"
+      );
+    });
 
     renderMeasureGroupComponent();
     await waitFor(() => {
@@ -1647,6 +1648,52 @@ describe("Delete Tests", () => {
       expect(editableContent).toHaveAttribute("contenteditable", "true");
       expect(editableContent).toHaveTextContent("");
     });
+  });
+
+  test("Group Delete blocked if any test case is locked by another user", async () => {
+    cohortGroup.id = "7p03-5r29-7O0I";
+    cohortGroup.groupDescription = "testDescription";
+    cohortMeasure.groups = [cohortGroup];
+    (useFeatureFlags as jest.Mock).mockClear().mockImplementation(() => ({
+      Locking: true,
+    }));
+    renderMeasureGroupComponent({
+      ...props,
+      checkTestCasesLockStatus: jest.fn().mockResolvedValue(true),
+    });
+
+    expect(screen.getByTestId("title").textContent).toBe(
+      "Population Criteria 1"
+    );
+
+    expect(screen.getByTestId("group-form-delete-btn")).toBeInTheDocument();
+    expect(screen.getByTestId("group-form-delete-btn")).toBeEnabled();
+
+    userEvent.click(screen.getByTestId("group-form-delete-btn"));
+
+    expect(
+      screen.getByTestId("delete-measure-group-modal-cancel-btn")
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByTestId("delete-measure-group-modal-agree-btn")
+    ).toBeInTheDocument();
+
+    act(() =>
+      userEvent.click(
+        screen.getByTestId("delete-measure-group-modal-agree-btn")
+      )
+    );
+
+    expect(mockMeasureServiceApi.deleteMeasureGroup).not.toBeCalled();
+    const errorToastMsg = await screen.findByText(
+      "This measure cannot be saved because changes to the Population Criteria will update test cases and one or more test cases are locked by another user."
+    );
+    expect(errorToastMsg).toBeInTheDocument();
+
+    renderMeasureGroupComponent();
+    const groupDescription = await screen.findByText("testDescription");
+    expect(groupDescription).toBeInTheDocument();
   });
 });
 

--- a/src/components/editMeasure/populationCriteria/groups/QDM/QDMMeasureGroups.tsx
+++ b/src/components/editMeasure/populationCriteria/groups/QDM/QDMMeasureGroups.tsx
@@ -331,16 +331,7 @@ const MeasureGroups = (props: MeasureGroupProps) => {
     ),
     onSubmit: async (group: Group) => {
       window.scrollTo(0, 0);
-      if (featureFlags.Locking && (await props.checkTestCasesLockStatus())) {
-        handleToast(
-          "danger",
-          "This measure cannot be saved because changes to the Population Criteria will update test cases and one or more test cases are locked by another user.",
-          true
-        );
-        formik.resetForm();
-        return;
-      }
-
+      if (await checkTestCasesLockStatus()) return;
       if (
         measure?.groups &&
         !(measureGroupNumber >= measure?.groups?.length) &&
@@ -372,6 +363,19 @@ const MeasureGroups = (props: MeasureGroupProps) => {
       validateForm();
     }
   }, [formik.values.populations, validateForm]);
+
+  const checkTestCasesLockStatus = async (): Promise<boolean> => {
+    if (featureFlags.Locking && (await props.checkTestCasesLockStatus())) {
+      handleToast(
+        "danger",
+        "This measure cannot be saved because changes to the Population Criteria will update test cases and one or more test cases are locked by another user.",
+        true
+      );
+      formik.resetForm();
+      return true;
+    }
+    return false;
+  };
 
   useEffect(() => {
     const subscription = measureStore.subscribe((measure: Measure) => {
@@ -626,8 +630,12 @@ const MeasureGroups = (props: MeasureGroupProps) => {
     setDeleteMeasureGroupDialog({ open: false });
   };
 
-  const deleteMeasureGroup = (e) => {
+  const deleteMeasureGroup = async (e) => {
     e.preventDefault();
+    if (await checkTestCasesLockStatus()) {
+      handleDialogClose();
+      return;
+    }
     measureServiceApi
       .deleteMeasureGroup(measure?.groups[measureGroupNumber]?.id, measure.id)
       .then((response) => {

--- a/src/components/editMeasure/populationCriteria/groups/QICore/QICoreMeasureGroups.test.tsx
+++ b/src/components/editMeasure/populationCriteria/groups/QICore/QICoreMeasureGroups.test.tsx
@@ -608,20 +608,10 @@ describe("Measure Groups Page", () => {
         screen.getByTestId("delete-measure-group-modal-agree-btn")
       );
 
-      expect(
-        await screen.findByTestId("group-form-delete-btn")
-      ).not.toBeInTheDocument();
-
-      await waitFor(() => {
-        expect(setAlertMessageMock).toHaveBeenCalled();
-      });
-
-      expect(setAlertMessageMock).toHaveBeenCalledWith({
-        type: "error",
-        message:
-          "The Population Criteria cannot be deleted because changes to the Population Criteria will update test cases and one or more test cases are locked by another user.",
-        canClose: false,
-      });
+      const errorToastMsg = await screen.findByText(
+        "This measure cannot be saved because changes to the Population Criteria will update test cases and one or more test cases are locked by another user."
+      );
+      expect(errorToastMsg).toBeInTheDocument();
 
       useFeatureFlags.mockImplementation(() => ({
         Locking: false,

--- a/src/components/editMeasure/populationCriteria/groups/QICore/QICoreMeasureGroups.tsx
+++ b/src/components/editMeasure/populationCriteria/groups/QICore/QICoreMeasureGroups.tsx
@@ -425,16 +425,7 @@ const MeasureGroups = (props: MeasureGroupProps) => {
     // enableReinitialize: true,
     onSubmit: async (group: Group) => {
       window.scrollTo(0, 0);
-      if (featureFlags.Locking && (await props.checkTestCasesLockStatus())) {
-        handleToast(
-          "danger",
-          "This measure cannot be saved because changes to the Population Criteria will update test cases and one or more test cases are locked by another user.",
-          true
-        );
-        formik.resetForm();
-        return;
-      }
-
+      if (await checkTestCasesLockStatus()) return;
       if (
         measure?.groups &&
         !(measureGroupNumber >= measure?.groups?.length) &&
@@ -461,6 +452,19 @@ const MeasureGroups = (props: MeasureGroupProps) => {
   });
   useFormikResetOnEvent(formik);
   const { resetForm, validateForm } = formik;
+
+  const checkTestCasesLockStatus = async (): Promise<boolean> => {
+    if (featureFlags.Locking && (await props.checkTestCasesLockStatus())) {
+      handleToast(
+        "danger",
+        "This measure cannot be saved because changes to the Population Criteria will update test cases and one or more test cases are locked by another user.",
+        true
+      );
+      formik.resetForm();
+      return true;
+    }
+    return false;
+  };
 
   useEffect(() => {
     if (measure?.groups && measure?.groups[measureGroupNumber]) {
@@ -665,8 +669,12 @@ const MeasureGroups = (props: MeasureGroupProps) => {
     setDeleteMeasureGroupDialog({ open: false });
   };
 
-  const deleteMeasureGroup = (e) => {
+  const deleteMeasureGroup = async (e) => {
     e.preventDefault();
+    if (await checkTestCasesLockStatus()) {
+      handleDialogClose();
+      return;
+    }
     measureServiceApi
       .deleteMeasureGroup(measure?.groups[measureGroupNumber]?.id, measure.id)
       .then((response) => {
@@ -676,7 +684,6 @@ const MeasureGroups = (props: MeasureGroupProps) => {
             "/" +
             (measureGroupNumber === 0 ? 1 : measureGroupNumber)
         );
-        handleDialogClose();
         if (response && response.groups?.length > 0) {
           setToastOpen(true);
           setToastType("success");
@@ -686,7 +693,6 @@ const MeasureGroups = (props: MeasureGroupProps) => {
         }
       })
       .catch((error) => {
-        handleDialogClose();
         if (error?.message.includes("locked")) {
           props.setAlertMessage({
             type: "error",
@@ -694,7 +700,6 @@ const MeasureGroups = (props: MeasureGroupProps) => {
               "The Population Criteria cannot be deleted because changes to the Population Criteria will update test cases and one or more test cases are locked by another user.",
             canClose: false,
           });
-          navigate(`${groupsBaseUrl}/${measureGroupNumber}`);
         } else {
           props.setAlertMessage({
             type: "error",
@@ -702,6 +707,9 @@ const MeasureGroups = (props: MeasureGroupProps) => {
             canClose: false,
           });
         }
+      })
+      .finally(() => {
+        handleDialogClose();
       });
   };
 


### PR DESCRIPTION
## MADiE PR

Jira Ticket: [MAT-9511](https://jira.cms.gov/browse/MAT-9511)
(Optional) Related Tickets:

### Summary

- MAT-9511: Handle TC lock live check result.
- MAT-9511: Prevent QDM Group deletion when any TC is locked by another user.

### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included.
* [ ] No extemporaneous files are included (i.e Complied files or testing results).
* [ ] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).
* [ ] All CDN/Web dependencies are hosted internally (i.e MADiE-Root Repo).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
