### PR TITLE
MAT-9660 showing harpId when first and last name is null

### DIFF
--- a/src/components/editMeasure/details/measureInformation/MeasureInformation.test.tsx
+++ b/src/components/editMeasure/details/measureInformation/MeasureInformation.test.tsx
@@ -1555,4 +1555,56 @@ describe("MeasureInformation component", () => {
       ).toBe("-");
     });
   });
+
+  it("sets only last name when the first name is null ", async () => {
+    mockUserServiceApi.getOwnerDetails.mockResolvedValueOnce({
+      firstName: null,
+      lastName: "Doe",
+    });
+
+    const { getByTestId } = render(
+      <MeasureInformation setErrorMessage={jest.fn()} measureCanEdit={true} />
+    );
+
+    await waitFor(() => {
+      expect(
+        (getByTestId("measure-owner-text-field") as HTMLInputElement).value
+      ).toBe("Doe");
+    });
+  });
+
+  it("sets only first name when the last name is null ", async () => {
+    mockUserServiceApi.getOwnerDetails.mockResolvedValueOnce({
+      firstName: "Jane",
+      lastName: null,
+    });
+
+    const { getByTestId } = render(
+      <MeasureInformation setErrorMessage={jest.fn()} measureCanEdit={true} />
+    );
+
+    await waitFor(() => {
+      expect(
+        (getByTestId("measure-owner-text-field") as HTMLInputElement).value
+      ).toBe("Jane");
+    });
+  });
+
+  it("sets harpId if both first name and last name are null ", async () => {
+    mockUserServiceApi.getOwnerDetails.mockResolvedValueOnce({
+      firstName: null,
+      lastName: null,
+      harpId: "jane@test",
+    });
+
+    const { getByTestId } = render(
+      <MeasureInformation setErrorMessage={jest.fn()} measureCanEdit={true} />
+    );
+
+    await waitFor(() => {
+      expect(
+        (getByTestId("measure-owner-text-field") as HTMLInputElement).value
+      ).toBe("jane@test");
+    });
+  });
 });


### PR DESCRIPTION
## MADiE PR

Jira Ticket: [MAT-9660](https://jira.cms.gov/browse/MAT-9660)
(Optional) Related Tickets:

### Summary
 showing harpId when first and last name is null
 
### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included.
* [ ] No extemporaneous files are included (i.e Complied files or testing results).
* [ ] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).
* [ ] All CDN/Web dependencies are hosted internally (i.e MADiE-Root Repo).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
