### PR TITLE
Mat9660 edge case bug, when the get owner details call fail in the edit measure screen

### DIFF
--- a/src/components/editMeasure/details/measureInformation/MeasureInformation.tsx
+++ b/src/components/editMeasure/details/measureInformation/MeasureInformation.tsx
@@ -109,7 +109,7 @@ export default function MeasureInformation(props: MeasureInformationProps) {
       : "-";
   };
 
-  useEffect(() => {
+   useEffect(() => {
     if (measure?.measureSet?.owner) {
       userServiceApi
         .getOwnerDetails(measure?.measureSet?.owner)
@@ -117,8 +117,10 @@ export default function MeasureInformation(props: MeasureInformationProps) {
           setMeasureOwner(getMeasureOwnerName(response));
         })
         .catch(() => {
-          setMeasureOwner("-");
+          setMeasureOwner(measure?.measureSet?.owner);
         });
+    } else {
+      setMeasureOwner("-");
     }
   }, [measure?.measureSet?.owner]);
 

--- a/src/components/editMeasure/testCases/api/useFhirDefinitionsService.ts
+++ b/src/components/editMeasure/testCases/api/useFhirDefinitionsService.ts
@@ -6,6 +6,7 @@ import { ResourceIdentifier } from "./models/ResourceIdentifier";
 import { StructureDefinitionDto } from "./models/StructureDefinitionDto";
 import { ValueSet } from "fhir/r4";
 import { TestCase } from "@madie/madie-models";
+import { qicoreVerionModelTypeMap } from "../util/CalculationTestHelpers";
 
 export interface TestCaseExecutionBundlesDTO {
   testCases: TestCase[];
@@ -78,13 +79,9 @@ export class FhirDefinitionsServiceApi {
     testCases: TestCase[]
   ): Promise<TestCaseExecutionBundlesDTO> {
     try {
-      const model = "4-1-1";
-      console.log(
-        `${this.baseUrl}/fhir/test-cases/qicore/${model}/execution-bundles`
-      );
-
+      const versionModel = qicoreVerionModelTypeMap(model);
       const response = await axios.post<TestCaseExecutionBundlesDTO>(
-        `${this.baseUrl}/fhir/test-cases/qicore/${model}/execution-bundles`,
+        `${this.baseUrl}/fhir/test-cases/qicore/${versionModel}/execution-bundles`,
         testCases,
         {
           headers: {

--- a/src/components/editMeasure/testCases/api/useFhirDefinitionsService.ts
+++ b/src/components/editMeasure/testCases/api/useFhirDefinitionsService.ts
@@ -5,6 +5,12 @@ import axios from "../../../../api/axios-instance";
 import { ResourceIdentifier } from "./models/ResourceIdentifier";
 import { StructureDefinitionDto } from "./models/StructureDefinitionDto";
 import { ValueSet } from "fhir/r4";
+import { TestCase } from "@madie/madie-models";
+
+export interface TestCaseExecutionBundlesDTO {
+  testCases: TestCase[];
+  modifiedTestCaseIds: string[];
+}
 
 export class FhirDefinitionsServiceApi {
   constructor(private baseUrl: string, private getAccessToken: () => string) {}
@@ -65,6 +71,34 @@ export class FhirDefinitionsServiceApi {
       );
     }
     return null;
+  }
+
+  async getTestCaseExecutionBundle(
+    model: string,
+    testCases: TestCase[]
+  ): Promise<TestCaseExecutionBundlesDTO> {
+    try {
+      const model = "4-1-1";
+      console.log(
+        `${this.baseUrl}/fhir/test-cases/qicore/${model}/execution-bundles`
+      );
+
+      const response = await axios.post<TestCaseExecutionBundlesDTO>(
+        `${this.baseUrl}/fhir/test-cases/qicore/${model}/execution-bundles`,
+        testCases,
+        {
+          headers: {
+            Authorization: `Bearer ${this.getAccessToken()}`,
+          },
+        }
+      );
+      return response.data;
+    } catch (error) {
+      console.error(
+        `An error occurred while generating test case execution bundle for model version [${model}]: `,
+        error
+      );
+    }
   }
 }
 

--- a/src/components/editMeasure/testCases/components/editTestCase/qiCore/EditTestCase.test.tsx
+++ b/src/components/editMeasure/testCases/components/editTestCase/qiCore/EditTestCase.test.tsx
@@ -3531,6 +3531,16 @@ describe("EditTestCase component", () => {
           data: testCase,
         });
       });
+      mockedAxios.post.mockClear().mockImplementation((args) => {
+        if (args && args.endsWith("execution-bundles")) {
+          return Promise.resolve({
+            data: {
+              testCases: [testCase],
+              modifiedTestCaseIds: ["1234"],
+            },
+          });
+        }
+      });
       renderWithRouter(
         [
           "/measures/623cacebe74613783378c17b/edit/test-cases/623cacffe74613783378c17c",
@@ -3568,22 +3578,32 @@ describe("EditTestCase component", () => {
           data: { ...testCaseFixture, createdBy: MEASURE_CREATEDBY },
         });
       });
-      mockedAxios.post.mockResolvedValue({
-        data: {
-          code: 200,
-          message: null,
-          successful: true,
-          outcomeResponse: {
-            resourceType: "OperationOutcome",
-            issue: [
-              {
-                severity: "informational",
-                code: "processing",
-                diagnostics: "No issues!",
-              },
-            ],
+      mockedAxios.post.mockClear().mockImplementation((args) => {
+        if (args && args.endsWith("execution-bundles")) {
+          return Promise.resolve({
+            data: {
+              testCases: [testCaseFixture],
+              modifiedTestCaseIds: [testCaseFixture.id],
+            },
+          });
+        }
+        return Promise.resolve({
+          data: {
+            code: 200,
+            message: null,
+            successful: true,
+            outcomeResponse: {
+              resourceType: "OperationOutcome",
+              issue: [
+                {
+                  severity: "informational",
+                  code: "processing",
+                  diagnostics: "No issues!",
+                },
+              ],
+            },
           },
-        },
+        });
       });
       const measure = { ...simpleMeasureFixture, createdBy: MEASURE_CREATEDBY };
       renderWithRouter(
@@ -3690,22 +3710,32 @@ describe("EditTestCase component", () => {
           data: { ...nonBoolTestCaseFixture, createdBy: MEASURE_CREATEDBY },
         });
       });
-      mockedAxios.post.mockResolvedValue({
-        data: {
-          code: 200,
-          message: null,
-          successful: true,
-          outcomeResponse: {
-            resourceType: "OperationOutcome",
-            issue: [
-              {
-                severity: "informational",
-                code: "processing",
-                diagnostics: "No issues!",
-              },
-            ],
+      mockedAxios.post.mockClear().mockImplementation((args) => {
+        if (args && args.endsWith("execution-bundles")) {
+          return Promise.resolve({
+            data: {
+              testCases: [nonBoolTestCaseFixture],
+              modifiedTestCaseIds: [nonBoolTestCaseFixture.id],
+            },
+          });
+        }
+        return Promise.resolve({
+          data: {
+            code: 200,
+            message: null,
+            successful: true,
+            outcomeResponse: {
+              resourceType: "OperationOutcome",
+              issue: [
+                {
+                  severity: "informational",
+                  code: "processing",
+                  diagnostics: "No issues!",
+                },
+              ],
+            },
           },
-        },
+        });
       });
       const measure = {
         ...multiGroupMeasureFixture,
@@ -3833,22 +3863,32 @@ describe("EditTestCase component", () => {
           data: testCase,
         });
       });
-      mockedAxios.post.mockResolvedValue({
-        data: {
-          code: 200,
-          message: null,
-          successful: false,
-          outcomeResponse: {
-            resourceType: "OperationOutcome",
-            issue: [
-              {
-                severity: "error",
-                code: "processing",
-                diagnostics: "Major issue on line 1!",
-              },
-            ],
+      mockedAxios.post.mockClear().mockImplementation((args) => {
+        if (args && args.endsWith("execution-bundles")) {
+          return Promise.resolve({
+            data: {
+              testCases: [testCaseFixture],
+              modifiedTestCaseIds: [testCaseFixture.id],
+            },
+          });
+        }
+        return Promise.resolve({
+          data: {
+            code: 200,
+            message: null,
+            successful: false,
+            outcomeResponse: {
+              resourceType: "OperationOutcome",
+              issue: [
+                {
+                  severity: "error",
+                  code: "processing",
+                  diagnostics: "Major issue on line 1!",
+                },
+              ],
+            },
           },
-        },
+        });
       });
       const measure = { ...simpleMeasureFixture, createdBy: MEASURE_CREATEDBY };
       renderWithRouter(
@@ -3891,22 +3931,32 @@ describe("EditTestCase component", () => {
           data: { ...testCaseFixture, createdBy: MEASURE_CREATEDBY },
         });
       });
-      mockedAxios.post.mockResolvedValue({
-        data: {
-          code: 200,
-          message: null,
-          successful: false,
-          outcomeResponse: {
-            resourceType: "OperationOutcome",
-            issue: [
-              {
-                severity: "error",
-                code: "processing",
-                diagnostics: "Major issue on line 1!",
-              },
-            ],
+      mockedAxios.post.mockClear().mockImplementation((args) => {
+        if (args && args.endsWith("execution-bundles")) {
+          return Promise.resolve({
+            data: {
+              testCases: [testCaseFixture],
+              modifiedTestCaseIds: [testCaseFixture.id],
+            },
+          });
+        }
+        return Promise.resolve({
+          data: {
+            code: 200,
+            message: null,
+            successful: false,
+            outcomeResponse: {
+              resourceType: "OperationOutcome",
+              issue: [
+                {
+                  severity: "error",
+                  code: "processing",
+                  diagnostics: "Major issue on line 1!",
+                },
+              ],
+            },
           },
-        },
+        });
       });
       const measure = { ...simpleMeasureFixture, createdBy: MEASURE_CREATEDBY };
       renderWithRouter(
@@ -4020,6 +4070,16 @@ describe("EditTestCase component", () => {
             hapiOperationOutcome: validationOutcome,
           },
         });
+      });
+      mockedAxios.post.mockClear().mockImplementation((args) => {
+        if (args && args.endsWith("execution-bundles")) {
+          return Promise.resolve({
+            data: {
+              testCases: [testCaseFixture],
+              modifiedTestCaseIds: [testCaseFixture.id],
+            },
+          });
+        }
       });
       const measure = { ...simpleMeasureFixture, createdBy: MEASURE_CREATEDBY };
       measure.testCaseConfiguration.executeInvalidTestCases = true;

--- a/src/components/editMeasure/testCases/components/editTestCase/qiCore/EditTestCase.tsx
+++ b/src/components/editMeasure/testCases/components/editTestCase/qiCore/EditTestCase.tsx
@@ -904,7 +904,7 @@ const EditTestCase = (props: EditTestCaseProps) => {
       const calculationOutput: CalculationOutput<any> =
         await calculation.current.calculateTestCases(
           measure,
-          updatedTestCaseExecutionBundle.testCases,
+          updatedTestCaseExecutionBundle?.testCases,
           measureBundle,
           valueSets
         );

--- a/src/components/editMeasure/testCases/components/editTestCase/qiCore/EditTestCase.tsx
+++ b/src/components/editMeasure/testCases/components/editTestCase/qiCore/EditTestCase.tsx
@@ -28,6 +28,7 @@ import {
   Measure,
 } from "@madie/madie-models";
 import useTestCaseServiceApi from "../../../api/useTestCaseServiceApi";
+import useFhirDefinitionsServiceApi from "../../../api/useFhirDefinitionsService";
 import Editor from "../../editor/Editor";
 import { TestCaseValidator } from "../../../validators/TestCaseValidator";
 import { MadieError, sanitizeUserInput } from "../../../util/Utils";
@@ -431,6 +432,7 @@ const EditTestCase = (props: EditTestCaseProps) => {
     []
   );
   const [callstackMap, setCallstackMap] = useState<CqlDefinitionCallstack>();
+  const fhirDefinitionServiceApi = useRef(useFhirDefinitionsServiceApi());
 
   const {
     measureState,
@@ -891,11 +893,18 @@ const EditTestCase = (props: EditTestCaseProps) => {
       }
     }
 
+    // filter any resources with invalid references.
+    const updatedTestCaseExecutionBundle =
+      await fhirDefinitionServiceApi.current.getTestCaseExecutionBundle(
+        measure.model,
+        [modifiedTestCase]
+      );
+
     try {
       const calculationOutput: CalculationOutput<any> =
         await calculation.current.calculateTestCases(
           measure,
-          [modifiedTestCase],
+          updatedTestCaseExecutionBundle.testCases,
           measureBundle,
           valueSets
         );

--- a/src/components/editMeasure/testCases/util/CalculationTestHelpers.test.ts
+++ b/src/components/editMeasure/testCases/util/CalculationTestHelpers.test.ts
@@ -1,5 +1,8 @@
 import * as _ from "lodash";
-import { getStatementRelevanceForPopulationSet } from "./CalculationTestHelpers";
+import {
+  getStatementRelevanceForPopulationSet,
+  qicoreVerionModelTypeMap,
+} from "./CalculationTestHelpers";
 
 describe("CalculationTestHelpers", () => {
   let testMeasure;
@@ -81,6 +84,16 @@ describe("CalculationTestHelpers", () => {
         "Numerator Observation"
       ]
     ).toBe("TRUE");
+  });
+
+  it("should return related version input based on QI-Core pattern", () => {
+    expect(qicoreVerionModelTypeMap("QI-Core v4.1.1")).toBe("4-1-1");
+    expect(qicoreVerionModelTypeMap("QI-Core v6.0.0")).toBe("6-0-0");
+    expect(qicoreVerionModelTypeMap("OtherModel v4.1.1")).toBe(
+      "OtherModel v4.1.1"
+    );
+    expect(qicoreVerionModelTypeMap("QI-Core 4.1.1")).toBe("QI-Core 4.1.1");
+    expect(qicoreVerionModelTypeMap("QI-Core v4.1")).toBe("QI-Core v4.1");
   });
 });
 

--- a/src/components/editMeasure/testCases/util/CalculationTestHelpers.ts
+++ b/src/components/editMeasure/testCases/util/CalculationTestHelpers.ts
@@ -316,3 +316,11 @@ function markStatementRelevant(
     }
   }
 }
+
+export function qicoreVerionModelTypeMap(version: string): string {
+  const match = version.match(/^QI-Core v(\d+\.\d+\.\d+)/i);
+  if (match && match[1]) {
+    return match[1].replace(/\./g, "-");
+  }
+  return version;
+}


### PR DESCRIPTION
## MADiE PR

Jira Ticket: [MAT-9660](https://jira.cms.gov/browse/MAT-9660)
(Optional) Related Tickets:

### Summary
edge case bug, when the get owner details call fail in the edit measure screen

### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included.
* [ ] No extemporaneous files are included (i.e Complied files or testing results).
* [ ] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).
* [ ] All CDN/Web dependencies are hosted internally (i.e MADiE-Root Repo).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
