### PR TITLE
MAT-9667: add RatioComponent for FHIR Ratio type support in test case…

### DIFF
--- a/src/components/editMeasure/testCases/api/fhirDefinitionServiceUtilities.tsx
+++ b/src/components/editMeasure/testCases/api/fhirDefinitionServiceUtilities.tsx
@@ -729,6 +729,7 @@ export function isComponentDataType(datatype) {
     case "reference":
     case "quantity":
     case "range":
+    case "ratio":
     case "period":
       return true;
     default:

--- a/src/components/editMeasure/testCases/components/editTestCase/qiCore/LeftPanel/ElementsTab/builder/element/TypeEditor.test.tsx
+++ b/src/components/editMeasure/testCases/components/editTestCase/qiCore/LeftPanel/ElementsTab/builder/element/TypeEditor.test.tsx
@@ -2337,6 +2337,68 @@ describe("TypeEditor Component", () => {
     expect(screen.queryByLabelText(/Comparator/i)).not.toBeInTheDocument();
   });
 
+  test("Should render Ratio component", async () => {
+    const mockFormik: FormikContextType<any> = {
+      values: {
+        "Observation.valueRatio": {
+          numerator: { value: "1" },
+          denominator: { value: "10" },
+        },
+      },
+      touched: {},
+      getFieldProps: (label) => {
+        const value = getNestedProperty(mockFormik.values, label);
+        return { value, name: label, onChange: jest.fn(), onBlur: jest.fn() };
+      },
+      handleChange: () => {},
+    } as unknown as FormikContextType<any>;
+
+    render(
+      <ExecutionContextProvider
+        value={{
+          measureState: [null, jest.fn()],
+          bundleState: [null, jest.fn()],
+          valueSetsState: [[], jest.fn()],
+          executionContextReady: true,
+          executing: false,
+          setExecuting: jest.fn(),
+          contextFailure: false,
+        }}
+      >
+        <FormikProvider value={mockFormik}>
+          <RequiredFieldsProvider requiredFields={{}} formInfo={[]}>
+            <TypeEditor
+              resource={null}
+              structureDefinition={{
+                id: "Observation.value[x]",
+                type: [{ code: "Ratio" }],
+                required: false,
+                canBeMultipleCardinality: false,
+                max: "1",
+                min: 0,
+              }}
+              label="Observation.valueRatio"
+              canEdit={true}
+              parentStructureDefinition={null}
+            />
+          </RequiredFieldsProvider>
+        </FormikProvider>
+      </ExecutionContextProvider>
+    );
+
+    const numeratorComponent = await screen.findByTestId(
+      "decimal-field-Observation.valueRatio.numerator.value"
+    );
+    expect(numeratorComponent).toBeInTheDocument();
+
+    const denominatorComponent = await screen.findByTestId(
+      "decimal-field-Observation.valueRatio.denominator.value"
+    );
+    expect(denominatorComponent).toBeInTheDocument();
+
+    expect(screen.queryByText("Comparator")).not.toBeInTheDocument();
+  });
+
   test("renders QuantityComponent fields correctly", async () => {
     useFhirDefinitionsServiceApiMock.mockImplementation(
       () =>

--- a/src/components/editMeasure/testCases/components/editTestCase/qiCore/LeftPanel/ElementsTab/builder/element/TypeEditor.tsx
+++ b/src/components/editMeasure/testCases/components/editTestCase/qiCore/LeftPanel/ElementsTab/builder/element/TypeEditor.tsx
@@ -49,6 +49,7 @@ import { IntegerType } from "./typesValidations/FhirNumbers";
 import ElementSectionQiCore from "./ElementSectionQiCore";
 import { getEmptyValueForType } from "./TypeEditorUtils";
 import { getMultipleCardinalityLabel } from "./types/TypeUtil";
+import RatioComponent from "./types/RatioComponent";
 
 export const formikErrorHandler = (name: string, formik) => {
   const touched = getNestedProperty(formik.touched, name);
@@ -361,6 +362,14 @@ const TypeEditor = ({
         );
         return wrapWithSection(label, markdown);
       case "Quantity":
+        // Show comparator for Quantity types that are NOT SimpleQuantity
+        const isSimpleQuantity = structureDefinition?.type?.some(
+          ({ code, profile }) =>
+            code === "Quantity" &&
+            profile?.includes(
+              "http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
+            )
+        );
         return (
           <>
             {(isArrayMode ? values : [null]).map((el, index) => {
@@ -373,7 +382,7 @@ const TypeEditor = ({
                   key={index}
                   canEdit={canEdit}
                   label={fieldLabel}
-                  structureDefinition={structureDefinition}
+                  showComparator={!isSimpleQuantity}
                   fieldRequired={required}
                   showAddAttributeButton={
                     showMultipleCardinalityActionCenter &&
@@ -751,11 +760,19 @@ const TypeEditor = ({
           <RangeComponent
             canEdit={canEdit}
             label={label}
-            structureDefinition={structureDefinition}
             fieldRequired={false}
           />
         );
         return wrapWithSection(label, range);
+      case "Ratio":
+        const ratio = (
+          <RatioComponent
+            canEdit={canEdit}
+            label={label}
+            fieldRequired={false}
+          />
+        );
+        return wrapWithSection(label, ratio);
       case "Coding":
         const coding = (
           <CodingComponent

--- a/src/components/editMeasure/testCases/components/editTestCase/qiCore/LeftPanel/ElementsTab/builder/element/types/QuantityComponent.test.tsx
+++ b/src/components/editMeasure/testCases/components/editTestCase/qiCore/LeftPanel/ElementsTab/builder/element/types/QuantityComponent.test.tsx
@@ -88,24 +88,9 @@ useTerminologyServiceApiMock.mockImplementation(() => ({
   getValueSetsExpansionForOids: jest.fn().mockResolvedValue([]),
 }));
 
-const quantityStructureDefinition = {
-  path: "Observation.quantity",
-  type: [{ code: "Quantity" }],
-};
-
-const simpleQuantityStructureDefinition = {
-  path: "Observation.simpleQuantity",
-  type: [
-    {
-      code: "Quantity",
-      profile: ["http://hl7.org/fhir/StructureDefinition/SimpleQuantity"],
-    },
-  ],
-};
-
 const renderWithFormik = ({
   label = "Observation.quantity",
-  structureDefinition = quantityStructureDefinition,
+  showComparator = true,
   canEdit = true,
   initialValues = {
     Observation: { quantity: { value: 10, code: "mg", comparator: ">" } },
@@ -132,7 +117,7 @@ const renderWithFormik = ({
         <QuantityComponent
           label={label}
           canEdit={canEdit}
-          structureDefinition={structureDefinition}
+          showComparator={showComparator}
           fieldRequired={false}
           showAddAttributeButton={showAddAttributeButton}
           addTitle={addTitle}
@@ -171,10 +156,10 @@ describe("QuantityComponent", () => {
     expect((codeInput as HTMLInputElement).value).toBe("mg");
   });
 
-  test("hides comparator field for SimpleQuantity structure definition because SimpleQuantity does not allow a comparator", async () => {
+  test("hides comparator field when showComparator is false", async () => {
     renderWithFormik({
       label: "Observation.quantity",
-      structureDefinition: simpleQuantityStructureDefinition,
+      showComparator: false,
     });
     expect(screen.queryByLabelText("Comparator")).not.toBeInTheDocument();
   });
@@ -281,7 +266,7 @@ describe("QuantityComponent", () => {
   test("displays validation error for invalid code 'z'", async () => {
     renderWithFormik({
       label: "Observation.quantity",
-      structureDefinition: quantityStructureDefinition,
+      showComparator: true,
       canEdit: true,
     });
 
@@ -299,7 +284,7 @@ describe("QuantityComponent", () => {
   test("does not display validation error for valid code 'mg'", async () => {
     renderWithFormik({
       label: "Observation.quantity",
-      structureDefinition: quantityStructureDefinition,
+      showComparator: true,
       canEdit: true,
     });
 
@@ -340,7 +325,7 @@ describe("QuantityComponent", () => {
               <QuantityComponent
                 label="Observation.quantity"
                 canEdit={true}
-                structureDefinition={quantityStructureDefinition}
+                showComparator={true}
               />
             );
           }}
@@ -398,7 +383,7 @@ describe("QuantityComponent", () => {
               <QuantityComponent
                 label="Observation.quantity"
                 canEdit={true}
-                structureDefinition={quantityStructureDefinition}
+                showComparator={true}
               />
             );
           }}
@@ -454,7 +439,7 @@ describe("QuantityComponent", () => {
               <QuantityComponent
                 label="Observation.quantity"
                 canEdit={true}
-                structureDefinition={quantityStructureDefinition}
+                showComparator={true}
               />
             );
           }}
@@ -509,7 +494,7 @@ describe("QuantityComponent", () => {
               <QuantityComponent
                 label="Observation.quantity"
                 canEdit={true}
-                structureDefinition={quantityStructureDefinition}
+                showComparator={true}
               />
             );
           }}
@@ -534,7 +519,7 @@ describe("QuantityComponent", () => {
   test("all fields are read-only when canEdit is false", async () => {
     renderWithFormik({
       label: "Observation.quantity",
-      structureDefinition: quantityStructureDefinition,
+      showComparator: true,
       canEdit: false,
     });
 

--- a/src/components/editMeasure/testCases/components/editTestCase/qiCore/LeftPanel/ElementsTab/builder/element/types/QuantityComponent.tsx
+++ b/src/components/editMeasure/testCases/components/editTestCase/qiCore/LeftPanel/ElementsTab/builder/element/types/QuantityComponent.tsx
@@ -17,6 +17,7 @@ import DecimalComponent from "./DecimalComponent";
 export interface QuantityComponentProps extends TypeComponentProps {
   showLabel?: boolean;
   valueFieldLabel?: string;
+  showComparator: boolean;
 }
 
 const QuantityComponent = ({
@@ -25,7 +26,7 @@ const QuantityComponent = ({
   name,
   showLabel = true,
   valueFieldLabel,
-  structureDefinition,
+  showComparator,
   showAddAttributeButton = false,
   addTitle = "",
   handleAddElement = () => {},
@@ -47,21 +48,6 @@ const QuantityComponent = ({
     formik.validateForm();
   };
 
-  /*
-    Determine whether to display the comparator field:
-
-    - Shown only for "Quantity" types that are NOT SimpleQuantity.
-    - Hidden for:
-        - SimpleQuantity (profile includes SimpleQuantity)
-        - Range types or any other type
-  */
-  const showComparator = structureDefinition?.type?.some(
-    ({ code, profile }) =>
-      code === "Quantity" &&
-      !profile?.includes(
-        "http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
-      )
-  );
   const comparatorPath = `${label}.comparator`;
   const comparator = getIn(formik.values, comparatorPath);
 

--- a/src/components/editMeasure/testCases/components/editTestCase/qiCore/LeftPanel/ElementsTab/builder/element/types/RangeComponent.scss
+++ b/src/components/editMeasure/testCases/components/editTestCase/qiCore/LeftPanel/ElementsTab/builder/element/types/RangeComponent.scss
@@ -6,6 +6,10 @@
     display: flex;
     align-items: flex-start;
 
+    > .element-editor-add-row {
+      flex: 0 0 max-content;
+    }
+
     .separator {
       margin: 35px 10px;
       font-weight: bold;

--- a/src/components/editMeasure/testCases/components/editTestCase/qiCore/LeftPanel/ElementsTab/builder/element/types/RangeComponent.tsx
+++ b/src/components/editMeasure/testCases/components/editTestCase/qiCore/LeftPanel/ElementsTab/builder/element/types/RangeComponent.tsx
@@ -16,31 +16,27 @@ const RangeComponent = ({ canEdit, label }: TypeComponentProps) => {
 
       <div className="quantity-row">
         {/* Low field */}
-        <div className="low-input">
-          <QuantityComponent
-            canEdit={canEdit}
-            label={lowPath}
-            showLabel={false}
-            showComparator={false}
-            valueFieldLabel="Low"
-            fieldRequired={false}
-          />
-        </div>
+        <QuantityComponent
+          canEdit={canEdit}
+          label={lowPath}
+          showLabel={false}
+          showComparator={false}
+          valueFieldLabel="Low"
+          fieldRequired={false}
+        />
 
         {/* Colon separator */}
         <span className="separator">:</span>
 
         {/* High field */}
-        <div className="high-input">
-          <QuantityComponent
-            canEdit={canEdit}
-            label={highPath}
-            showLabel={false}
-            showComparator={false}
-            valueFieldLabel="High"
-            fieldRequired={false}
-          />
-        </div>
+        <QuantityComponent
+          canEdit={canEdit}
+          label={highPath}
+          showLabel={false}
+          showComparator={false}
+          valueFieldLabel="High"
+          fieldRequired={false}
+        />
       </div>
     </div>
   );

--- a/src/components/editMeasure/testCases/components/editTestCase/qiCore/LeftPanel/ElementsTab/builder/element/types/RatioComponent.scss
+++ b/src/components/editMeasure/testCases/components/editTestCase/qiCore/LeftPanel/ElementsTab/builder/element/types/RatioComponent.scss
@@ -6,6 +6,10 @@
     display: flex;
     align-items: flex-start;
 
+    > .element-editor-add-row {
+      flex: 0 0 max-content;
+    }
+
     .separator {
       margin: 35px 10px;
       font-weight: bold;

--- a/src/components/editMeasure/testCases/components/editTestCase/qiCore/LeftPanel/ElementsTab/builder/element/types/RatioComponent.scss
+++ b/src/components/editMeasure/testCases/components/editTestCase/qiCore/LeftPanel/ElementsTab/builder/element/types/RatioComponent.scss
@@ -1,4 +1,4 @@
-.range-component {
+.ratio-component {
   display: flex;
   flex-direction: column;
 

--- a/src/components/editMeasure/testCases/components/editTestCase/qiCore/LeftPanel/ElementsTab/builder/element/types/RatioComponent.test.tsx
+++ b/src/components/editMeasure/testCases/components/editTestCase/qiCore/LeftPanel/ElementsTab/builder/element/types/RatioComponent.test.tsx
@@ -1,0 +1,203 @@
+import * as React from "react";
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  within,
+} from "@testing-library/react";
+import { Formik } from "formik";
+import { ExecutionContextProvider } from "../../../../../../../routes/qiCore/ExecutionContext";
+import RatioComponent from "./RatioComponent";
+import useTerminologyServiceApi, {
+  TerminologyServiceApi,
+} from "../../../../../../../../api/useTerminologyServiceApi";
+
+jest.mock("../../../../../../../../api/useTerminologyServiceApi");
+
+jest.mock("../../../../../../../common/quantityInput/validate", () => ({
+  validate: (unitValue: string) => {
+    if (unitValue === "z") {
+      return {
+        error: true,
+        helperText: "z is not a valid UCUM code. No alternatives were found.",
+      };
+    }
+    return { error: false, helperText: "" };
+  },
+  ValidationResult: class {
+    label?: string;
+    helperText?: string;
+    error = false;
+  },
+  ADDITIONAL_UCUM_UNIT_SUPPORT: {},
+}));
+
+const useTerminologyServiceApiMock =
+  useTerminologyServiceApi as jest.Mock<TerminologyServiceApi>;
+
+useTerminologyServiceApiMock.mockImplementation(() => ({
+  getValueSetsExpansionForOids: jest.fn().mockResolvedValue([]),
+}));
+
+const ratioStructureDefinition = {
+  path: "Observation.value[x]",
+  type: [{ code: "Ratio" }],
+};
+
+const renderWithFormik = ({
+  label = "Observation.valueRatio",
+  structureDefinition = ratioStructureDefinition,
+  canEdit = true,
+  initialValues = {
+    Observation: {
+      valueRatio: {
+        numerator: { value: 1, code: "mg" },
+        denominator: { value: 10, code: "mL" },
+      },
+    },
+  },
+} = {}) =>
+  render(
+    <ExecutionContextProvider
+      value={{
+        measureState: [null, jest.fn()],
+        bundleState: [null, jest.fn()],
+        valueSetsState: [[], jest.fn()],
+        executionContextReady: true,
+        executing: false,
+        setExecuting: jest.fn(),
+        contextFailure: false,
+      }}
+    >
+      <Formik initialValues={initialValues} onSubmit={jest.fn()}>
+        <RatioComponent
+          label={label}
+          canEdit={canEdit}
+          structureDefinition={structureDefinition}
+          fieldRequired={false}
+        />
+      </Formik>
+    </ExecutionContextProvider>
+  );
+
+describe("RatioComponent", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("renders numerator and denominator QuantityComponent fields with initial values", async () => {
+    renderWithFormik();
+
+    const numeratorContainer = screen
+      .getByText("Numerator")
+      .closest(".quantity-fields")!;
+    const inputNumerator = within(numeratorContainer).getByTestId(
+      "decimal-field-input-Observation.valueRatio.numerator.value"
+    ) as HTMLInputElement;
+    const codeNumerator = within(numeratorContainer).getByTestId(
+      "code-input-input"
+    ) as HTMLInputElement;
+
+    expect(inputNumerator.value).toBe("1");
+    expect(codeNumerator.value).toBe("mg");
+
+    const denominatorContainer = screen
+      .getByText("Denominator")
+      .closest(".quantity-fields")!;
+    const inputDenominator = within(denominatorContainer).getByTestId(
+      "decimal-field-input-Observation.valueRatio.denominator.value"
+    ) as HTMLInputElement;
+    const codeDenominator = within(denominatorContainer).getByTestId(
+      "code-input-input"
+    ) as HTMLInputElement;
+
+    expect(inputDenominator.value).toBe("10");
+    expect(codeDenominator.value).toBe("mL");
+
+    // Comparator should not be rendered for RatioComponent
+    expect(screen.queryByText("Comparator")).not.toBeInTheDocument();
+  });
+
+  test("updates numerator and denominator values correctly", async () => {
+    renderWithFormik();
+
+    const numeratorContainer = screen
+      .getByText("Numerator")
+      .closest(".quantity-fields")!;
+    const inputNumerator = within(numeratorContainer).getByTestId(
+      "decimal-field-input-Observation.valueRatio.numerator.value"
+    ) as HTMLInputElement;
+
+    const denominatorContainer = screen
+      .getByText("Denominator")
+      .closest(".quantity-fields")!;
+    const inputDenominator = within(denominatorContainer).getByTestId(
+      "decimal-field-input-Observation.valueRatio.denominator.value"
+    ) as HTMLInputElement;
+
+    fireEvent.change(inputNumerator, { target: { value: "5" } });
+    fireEvent.change(inputDenominator, { target: { value: "100" } });
+
+    await waitFor(() => {
+      expect(inputNumerator.value).toBe("5");
+      expect(inputDenominator.value).toBe("100");
+    });
+  });
+
+  test("updates numerator and denominator units correctly", async () => {
+    renderWithFormik();
+
+    const numeratorContainer = screen
+      .getByText("Numerator")
+      .closest(".quantity-fields")!;
+    const codeNumerator = within(numeratorContainer).getByTestId(
+      "code-input-input"
+    ) as HTMLInputElement;
+
+    const denominatorContainer = screen
+      .getByText("Denominator")
+      .closest(".quantity-fields")!;
+    const codeDenominator = within(denominatorContainer).getByTestId(
+      "code-input-input"
+    ) as HTMLInputElement;
+
+    fireEvent.change(codeNumerator, { target: { value: "g" } });
+    fireEvent.change(codeDenominator, { target: { value: "L" } });
+
+    await waitFor(() => {
+      expect(codeNumerator.value).toBe("g");
+      expect(codeDenominator.value).toBe("L");
+    });
+  });
+
+  test("all fields are read-only when canEdit is false", async () => {
+    renderWithFormik({ canEdit: false });
+
+    const numeratorContainer = screen
+      .getByText("Numerator")
+      .closest(".quantity-fields")!;
+    const denominatorContainer = screen
+      .getByText("Denominator")
+      .closest(".quantity-fields")!;
+
+    const inputNumerator = screen.getByTestId(
+      "decimal-field-Observation.valueRatio.numerator.value"
+    ) as HTMLInputElement;
+    const codeNumerator = within(numeratorContainer).getByTestId(
+      "code-input-Observation.valueRatio.numerator"
+    ) as HTMLTextAreaElement;
+
+    const inputDenominator = within(denominatorContainer).getByTestId(
+      "decimal-field-Observation.valueRatio.denominator.value"
+    ) as HTMLTextAreaElement;
+    const codeDenominator = within(denominatorContainer).getByTestId(
+      "code-input-Observation.valueRatio.denominator"
+    ) as HTMLTextAreaElement;
+
+    expect(inputNumerator).toHaveAttribute("readonly");
+    expect(codeNumerator).toHaveAttribute("readonly");
+    expect(inputDenominator).toHaveAttribute("readonly");
+    expect(codeDenominator).toHaveAttribute("readonly");
+  });
+});

--- a/src/components/editMeasure/testCases/components/editTestCase/qiCore/LeftPanel/ElementsTab/builder/element/types/RatioComponent.tsx
+++ b/src/components/editMeasure/testCases/components/editTestCase/qiCore/LeftPanel/ElementsTab/builder/element/types/RatioComponent.tsx
@@ -16,31 +16,27 @@ const RatioComponent = ({ canEdit, label }: TypeComponentProps) => {
 
       <div className="quantity-row">
         {/* Numerator field */}
-        <div className="low-input">
-          <QuantityComponent
-            canEdit={canEdit}
-            label={numeratorPath}
-            showLabel={false}
-            showComparator={false}
-            valueFieldLabel="Numerator"
-            fieldRequired={false}
-          />
-        </div>
+        <QuantityComponent
+          canEdit={canEdit}
+          label={numeratorPath}
+          showLabel={false}
+          showComparator={false}
+          valueFieldLabel="Numerator"
+          fieldRequired={false}
+        />
 
         {/* Colon separator */}
         <span className="separator">:</span>
 
         {/* Denominator field */}
-        <div className="high-input">
-          <QuantityComponent
-            canEdit={canEdit}
-            label={denominatorPath}
-            showLabel={false}
-            showComparator={false}
-            valueFieldLabel="Denominator"
-            fieldRequired={false}
-          />
-        </div>
+        <QuantityComponent
+          canEdit={canEdit}
+          label={denominatorPath}
+          showLabel={false}
+          showComparator={false}
+          valueFieldLabel="Denominator"
+          fieldRequired={false}
+        />
       </div>
     </div>
   );

--- a/src/components/editMeasure/testCases/components/editTestCase/qiCore/LeftPanel/ElementsTab/builder/element/types/RatioComponent.tsx
+++ b/src/components/editMeasure/testCases/components/editTestCase/qiCore/LeftPanel/ElementsTab/builder/element/types/RatioComponent.tsx
@@ -1,28 +1,28 @@
 import React from "react";
 import { InputLabel } from "@madie/madie-design-system/dist/react/";
 import { TypeComponentProps } from "./TypeComponentProps";
-import "./RangeComponent.scss";
+import "./RatioComponent.scss";
 import QuantityComponent from "./QuantityComponent";
 import { getMultipleCardinalityLabel } from "./TypeUtil";
 
-const RangeComponent = ({ canEdit, label }: TypeComponentProps) => {
+const RatioComponent = ({ canEdit, label }: TypeComponentProps) => {
   const formattedLabel = getMultipleCardinalityLabel(label);
-  const lowPath = `${label}.low`;
-  const highPath = `${label}.high`;
+  const numeratorPath = `${label}.numerator`;
+  const denominatorPath = `${label}.denominator`;
 
   return (
-    <div className="range-component" data-component-type="RangeComponent">
+    <div className="ratio-component" data-component-type="RatioComponent">
       <InputLabel>{formattedLabel}</InputLabel>
 
       <div className="quantity-row">
-        {/* Low field */}
+        {/* Numerator field */}
         <div className="low-input">
           <QuantityComponent
             canEdit={canEdit}
-            label={lowPath}
+            label={numeratorPath}
             showLabel={false}
             showComparator={false}
-            valueFieldLabel="Low"
+            valueFieldLabel="Numerator"
             fieldRequired={false}
           />
         </div>
@@ -30,14 +30,14 @@ const RangeComponent = ({ canEdit, label }: TypeComponentProps) => {
         {/* Colon separator */}
         <span className="separator">:</span>
 
-        {/* High field */}
+        {/* Denominator field */}
         <div className="high-input">
           <QuantityComponent
             canEdit={canEdit}
-            label={highPath}
+            label={denominatorPath}
             showLabel={false}
             showComparator={false}
-            valueFieldLabel="High"
+            valueFieldLabel="Denominator"
             fieldRequired={false}
           />
         </div>
@@ -46,4 +46,4 @@ const RangeComponent = ({ canEdit, label }: TypeComponentProps) => {
   );
 };
 
-export default RangeComponent;
+export default RatioComponent;


### PR DESCRIPTION
… builder

Added RatioComponent with numerator/denominator Quantity fields rendered as
SimpleQuantity (no comparator). Also, refactored QuantityComponent to accept
showComparator as a required prop instead of deriving it internally from
structureDefinition.type, preventing incorrect comparator display when
ChoiceType passes a structureDefinition containing both Quantity and
Range/Ratio types.

## MADiE PR

Jira Ticket: [MAT-9667](https://jira.cms.gov/browse/MAT-9667)
(Optional) Related Tickets:

<img width="1217" height="1217" alt="image" src="https://github.com/user-attachments/assets/cb3f88d6-f7f4-4300-ba3e-404f3a30845f" />

<img width="1217" height="1280" alt="image" src="https://github.com/user-attachments/assets/18a8959e-3432-4ca5-9e38-7e81e85fe4b9" />

### Summary

### All Submissions
* [x] This PR has the JIRA linked.
* [x] Required tests are included.
* [x] No extemporaneous files are included (i.e Complied files or testing results).
* [x] This PR is merging into the **correct branch**.
* [x] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).
* [ ] All CDN/Web dependencies are hosted internally (i.e MADiE-Root Repo).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
