### PR TITLE
MAT-9962 Allow invalid Patient references in test cases into test cas…

### DIFF
--- a/src/components/editMeasure/testCases/api/FhirDefinitionService.test.ts
+++ b/src/components/editMeasure/testCases/api/FhirDefinitionService.test.ts
@@ -74,7 +74,8 @@ describe("MeasureServiceApi", () => {
     await expect(
       fhirDefinitionsServiceApi.getTestCaseExecutionBundle(
         "QI-Core v4.1.1",
-        mockTestCases
+        mockTestCases,
+        false
       )
     ).rejects.toThrow(
       "An error occurred while generating test case execution bundle. Please try again."
@@ -103,7 +104,8 @@ describe("MeasureServiceApi", () => {
     await expect(
       fhirDefinitionsServiceApi.getTestCaseExecutionBundle(
         "QI-Core v4.1.1",
-        mockTestCases
+        mockTestCases,
+        false
       )
     ).rejects.toThrow(
       "Test case execution was cancelled because Unknown element 'entryd' found during parse. If this error persists, please contact support."
@@ -125,7 +127,8 @@ describe("MeasureServiceApi", () => {
     await expect(
       fhirDefinitionsServiceApi.getTestCaseExecutionBundle(
         "QI-Core v4.1.1",
-        mockTestCases
+        mockTestCases,
+        false
       )
     ).rejects.toThrow(
       "An error occurred while generating test case execution bundle. Please try again."

--- a/src/components/editMeasure/testCases/api/useFhirDefinitionsService.ts
+++ b/src/components/editMeasure/testCases/api/useFhirDefinitionsService.ts
@@ -76,7 +76,8 @@ export class FhirDefinitionsServiceApi {
 
   async getTestCaseExecutionBundle(
     model: string,
-    testCases: TestCase[]
+    testCases: TestCase[],
+    allowInvalidRefsForPatient: boolean
   ): Promise<TestCaseExecutionBundlesDTO> {
     try {
       const versionModel = qicoreVerionModelTypeMap(model);
@@ -84,6 +85,7 @@ export class FhirDefinitionsServiceApi {
         `${this.baseUrl}/fhir/test-cases/qicore/${versionModel}/execution-bundles`,
         testCases,
         {
+          params: { allowInvalidRefsForPatient },
           headers: {
             Authorization: `Bearer ${this.getAccessToken()}`,
           },

--- a/src/components/editMeasure/testCases/api/useTestCaseServiceApi.ts
+++ b/src/components/editMeasure/testCases/api/useTestCaseServiceApi.ts
@@ -224,13 +224,17 @@ export class TestCaseServiceApi {
     );
   }
 
-  async validateTestCaseBundle(bundle: any, model: string) {
+  async validateTestCaseBundle(
+    bundle: any,
+    model: string,
+    lenientPatientRefs: boolean
+  ): Promise<HapiOperationOutcome> {
     try {
       const response = await axios.post<HapiOperationOutcome>(
         `${this.baseUrl}/validations/bundles`,
         bundle,
         {
-          params: { model: model },
+          params: { model: model, lenientPatientRefs: lenientPatientRefs },
           headers: {
             Authorization: `Bearer ${this.getAccessToken()}`,
           },

--- a/src/components/editMeasure/testCases/components/editTestCase/qiCore/EditTestCase.test.tsx
+++ b/src/components/editMeasure/testCases/components/editTestCase/qiCore/EditTestCase.test.tsx
@@ -46,11 +46,7 @@ import { multiGroupMeasureFixture } from "../../createTestCase/__mocks__/multiGr
 import { nonBoolTestCaseFixture } from "../../createTestCase/__mocks__/nonBoolTestCaseFixture";
 import { TestCaseValidator } from "../../../validators/TestCaseValidator";
 // @ts-ignore
-import {
-  checkUserCanEdit,
-  useFeatureFlags,
-  MeasureServiceApi,
-} from "@madie/madie-util";
+import { checkUserCanEdit, MeasureServiceApi } from "@madie/madie-util";
 import { PopulationType as FqmPopulationType } from "fqm-execution/build/types/Enums";
 import { ResourceIdentifier } from "../../../api/models/ResourceIdentifier";
 
@@ -3126,6 +3122,114 @@ describe("EditTestCase component", () => {
       });
 
       expect(mockedAxios.get).toHaveBeenCalledTimes(3);
+    });
+
+    it("should call onUpdate and update the test case when polling returns a completed validation", async () => {
+      jest.useFakeTimers("modern");
+      const testCaseJson = JSON.stringify({
+        resourceType: "Bundle",
+        type: "collection",
+        entry: [
+          {
+            resource: {
+              resourceType: "Patient",
+              id: "patient-1",
+            },
+          },
+        ],
+      });
+      const testCase = {
+        id: "1234",
+        createdBy: MEASURE_CREATEDBY,
+        description: "Test IPP",
+        series: "SeriesA",
+        title: "TestIPP",
+        name: "TestIPP",
+        json: testCaseJson,
+        validationStatus: ValidationStatus.PENDING,
+        hapiOperationOutcome: null,
+        groupPopulations: [
+          {
+            groupId: "Group1_ID",
+            scoring: "Cohort",
+            populationValues: [
+              {
+                id: "id-1",
+                name: PopulationType.INITIAL_POPULATION,
+                expected: false,
+                actual: false,
+              },
+            ],
+          },
+        ],
+      } as unknown as TestCase;
+
+      const updatedTestCase = {
+        ...testCase,
+        validationStatus: ValidationStatus.VALID,
+        hapiOperationOutcome: hapiOperationSuccessOutcome,
+      };
+
+      const measure = {
+        id: "m1234",
+        createdBy: MEASURE_CREATEDBY,
+        model: Model.QICORE,
+        testCases: [],
+        groups: [
+          {
+            id: "Group1_ID",
+            scoring: "Cohort",
+            populations: [
+              {
+                id: "id-1",
+                name: PopulationType.INITIAL_POPULATION,
+                definition: "Pop1",
+              },
+            ],
+          },
+        ],
+      } as unknown as Measure;
+
+      let testCaseGetCount = 0;
+      mockedAxios.get.mockClear().mockImplementation((args) => {
+        if (args && args.endsWith("series")) {
+          return Promise.resolve({ data: ["SeriesA"] });
+        } else if (args && args.endsWith("resources")) {
+          return Promise.resolve({ data: [...resourceIdentifiers] });
+        }
+        testCaseGetCount++;
+        if (testCaseGetCount === 1) {
+          return Promise.resolve({ data: testCase });
+        }
+        return Promise.resolve({ data: updatedTestCase });
+      });
+
+      await act(async () => {
+        renderWithRouter(
+          ["/measures/m1234/edit/test-cases/1234"],
+          "/measures/:measureId/edit/test-cases/:id",
+          measure
+        );
+      });
+
+      // Initial state should show pending/validating spinner since status is PENDING
+      expect(testCaseGetCount).toBeGreaterThanOrEqual(1);
+
+      // Advance timers to trigger polling which returns VALID status
+      await act(async () => {
+        jest.advanceTimersByTime(5000);
+      });
+
+      // onUpdate should have been invoked - assert the polling fetched the updated test case
+      expect(testCaseGetCount).toBeGreaterThanOrEqual(2);
+
+      // After onUpdate processes the result, the validation status icon should change to valid
+      await act(async () => {
+        jest.advanceTimersByTime(0);
+      });
+
+      const validIcon = screen.queryByTestId("validation-header-valid-icon");
+      expect(validIcon).toBeInTheDocument();
     });
 
     it("should handle displaying a test case with null groupPopulation data", async () => {

--- a/src/components/editMeasure/testCases/components/editTestCase/qiCore/EditTestCase.tsx
+++ b/src/components/editMeasure/testCases/components/editTestCase/qiCore/EditTestCase.tsx
@@ -85,8 +85,10 @@ import useFormikResetOnEvent from "../../../../../common/useFormikResetOnEvent";
 import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc";
 import {
+  createUnresolvedPatientReferenceWarningDetails,
   extractValidationErrorsFromOutcome,
   isHapiOutcomeIssueCodeInformational,
+  upsertExecuteInvalidTestCaseWarning,
 } from "./EditTestCaseUtil";
 import { useTestCasePolling } from "../../../hooks/useTestCasePolling";
 import KeyboardTabIcon from "@mui/icons-material/KeyboardTab";
@@ -388,6 +390,7 @@ export interface EditTestCaseProps {
 
 const EditTestCase = (props: EditTestCaseProps) => {
   useDocumentTitle("MADiE Edit Measure Edit Test Case");
+  const { setCustomWarningMessages } = props;
   const navigate = useNavigate();
   const { measureId, id } = useParams<
     keyof navigationParams
@@ -451,7 +454,8 @@ const EditTestCase = (props: EditTestCaseProps) => {
   const [discardDialogOpen, setDiscardDialogOpen] = useState(false);
   const [calculationDialogOpen, setCalculationDialogOpen] = useState(false);
   const { updateMeasure } = measureStore;
-
+  const executeInvalidTestCases =
+    measure?.testCaseConfiguration?.executeInvalidTestCases;
   const canEdit = checkUserCanEdit(
     measure?.measureSet?.owner,
     measure?.measureSet?.acls
@@ -483,6 +487,22 @@ const EditTestCase = (props: EditTestCaseProps) => {
   useFormikResetOnEvent(formikStu6Context);
   const [shouldPoll, setShouldPoll] = useState(false);
 
+  const updateUnresolvedPatientReferenceWarnings = useCallback(
+    (errors: any[]) => {
+      const warningMessages = createUnresolvedPatientReferenceWarningDetails(
+        errors,
+        (resourceId) =>
+          `Resource ${resourceId} contains a reference that does not resolve within the bundle`
+      );
+
+      upsertExecuteInvalidTestCaseWarning(
+        setCustomWarningMessages,
+        warningMessages
+      );
+    },
+    [setCustomWarningMessages]
+  );
+
   const isQiCoreV6 = measure?.model === "QI-Core v6.0.0";
   // testCase polling, gets triggered when validationStatus is either Pending or Validating
   useTestCasePolling({
@@ -491,7 +511,10 @@ const EditTestCase = (props: EditTestCaseProps) => {
     shouldStart: shouldPoll,
     onUpdate: (updatedTc: TestCase) => {
       const nextTc = _.cloneDeep(updatedTc);
-      handleHapiOutcome(nextTc?.hapiOperationOutcome);
+      const validationErrors = handleHapiOutcome(nextTc?.hapiOperationOutcome);
+      if (executeInvalidTestCases) {
+        updateUnresolvedPatientReferenceWarnings(validationErrors);
+      }
       nextTc.json = standardizeJson(nextTc);
       setTestCase(nextTc);
     },
@@ -611,10 +634,16 @@ const EditTestCase = (props: EditTestCaseProps) => {
             tc.validationStatus
           )
         ) {
+          updateUnresolvedPatientReferenceWarnings([]);
           setShouldPoll(true);
         } else {
           setShouldPoll(false);
-          handleHapiOutcome(nextTc?.hapiOperationOutcome);
+          const validationErrors = handleHapiOutcome(
+            nextTc?.hapiOperationOutcome
+          );
+          if (executeInvalidTestCases) {
+            updateUnresolvedPatientReferenceWarnings(validationErrors);
+          }
         }
       })
       .catch((error) => {
@@ -686,6 +715,7 @@ const EditTestCase = (props: EditTestCaseProps) => {
     mapMeasureGroups,
     seriesState.loaded,
     canEdit,
+    updateUnresolvedPatientReferenceWarnings,
   ]);
 
   const testCaseCanEdit = canEdit && !testCase?.testCaseLock;
@@ -868,16 +898,14 @@ const EditTestCase = (props: EditTestCaseProps) => {
     }
     let modifiedTestCase = { ...testCase, json: editorVal };
     // validate the JSON iff executeInvalidTestCases is false and JSON has been modified
-    if (
-      !measure?.testCaseConfiguration?.executeInvalidTestCases &&
-      isJsonModified()
-    ) {
+    if (!executeInvalidTestCases && isJsonModified()) {
       try {
         // Validate test case JSON prior to execution
         const validationResult =
           await testCaseService.current.validateTestCaseBundle(
             JSON.parse(editorVal),
-            measure.model
+            measure.model,
+            executeInvalidTestCases
           );
         const errors = handleHapiOutcome(validationResult);
         if (
@@ -905,17 +933,14 @@ const EditTestCase = (props: EditTestCaseProps) => {
     }
 
     try {
-      let executionBundle: any = [modifiedTestCase];
-      if (!measure?.testCaseConfiguration?.executeInvalidTestCases) {
-        // Filter any resources with invalid references.
-        const updatedTestCaseExecutionBundle =
-          await fhirDefinitionServiceApi.current.getTestCaseExecutionBundle(
-            measure.model,
-            [modifiedTestCase]
-          );
-        executionBundle = updatedTestCaseExecutionBundle?.testCases;
-      }
-
+      // Filter any resources with invalid references.
+      const updatedTestCaseExecutionBundle =
+        await fhirDefinitionServiceApi.current.getTestCaseExecutionBundle(
+          measure.model,
+          [modifiedTestCase],
+          executeInvalidTestCases
+        );
+      const executionBundle = updatedTestCaseExecutionBundle?.testCases;
       const calculationOutput: CalculationOutput<any> =
         await calculation.current.calculateTestCases(
           measure,
@@ -1015,7 +1040,7 @@ const EditTestCase = (props: EditTestCaseProps) => {
     }
 
     if (customMessage.length > 0) {
-      props.setCustomWarningMessages([
+      setCustomWarningMessages([
         {
           message: `Test case ${action}d successfully!`,
           details: [...customMessage],

--- a/src/components/editMeasure/testCases/components/editTestCase/qiCore/EditTestCase.tsx
+++ b/src/components/editMeasure/testCases/components/editTestCase/qiCore/EditTestCase.tsx
@@ -933,7 +933,9 @@ const EditTestCase = (props: EditTestCaseProps) => {
     }
 
     try {
-      // Filter any resources with invalid references.
+      // Filter resources with invalid references based on executeInvalidTestCases.
+      // for executeInvalidTestCases=true, filter out non-patient resources with invalid refs
+      // for executeInvalidTestCases=false, filter out all resources with invalid refs
       const updatedTestCaseExecutionBundle =
         await fhirDefinitionServiceApi.current.getTestCaseExecutionBundle(
           measure.model,

--- a/src/components/editMeasure/testCases/components/editTestCase/qiCore/EditTestCaseUtil.test.ts
+++ b/src/components/editMeasure/testCases/components/editTestCase/qiCore/EditTestCaseUtil.test.ts
@@ -1,0 +1,127 @@
+import {
+  createUnresolvedPatientReferenceWarningDetails,
+  extractUnresolvedPatientReferenceResourceIds,
+  upsertExecuteInvalidTestCaseWarning,
+} from "./EditTestCaseUtil";
+import {
+  EXECUTE_INVALID_TEST_CASES_WARNING,
+  EXECUTE_INVALID_TEST_WARNING_TEST_DATA_ID,
+} from "../../testCaseConfiguration/executionOptions/ExecutionOptions";
+
+describe("extractUnresolvedPatientReferenceResourceIds", () => {
+  it("returns matching unresolved patient reference resource ids", () => {
+    const validationErrors = [
+      {
+        diagnostics:
+          "Resource [Patient/123e4567-e89b-12d3-a456-426614174000] contains a reference that does not resolve within the bundle",
+      },
+      {
+        diagnostics: "Some other validation warning",
+      },
+    ];
+
+    expect(
+      extractUnresolvedPatientReferenceResourceIds(validationErrors)
+    ).toEqual(["Patient/123e4567-e89b-12d3-a456-426614174000"]);
+  });
+
+  it("returns unique resource ids when duplicates are present", () => {
+    const unresolvedWarningDiagnostics =
+      "Resource [Patient/123e4567-e89b-12d3-a456-426614174000] contains a reference that does not resolve within the bundle";
+
+    const validationErrors = [
+      { diagnostics: unresolvedWarningDiagnostics },
+      { diagnostics: unresolvedWarningDiagnostics },
+    ];
+
+    expect(
+      extractUnresolvedPatientReferenceResourceIds(validationErrors)
+    ).toEqual(["Patient/123e4567-e89b-12d3-a456-426614174000"]);
+  });
+
+  it("returns an empty array when no matching diagnostics are present", () => {
+    const validationErrors = [
+      { diagnostics: "Warning: unexpected profile" },
+      { diagnostics: "Error: invalid code" },
+    ];
+
+    expect(
+      extractUnresolvedPatientReferenceResourceIds(validationErrors)
+    ).toEqual([]);
+  });
+});
+
+describe("createUnresolvedPatientReferenceWarningDetails", () => {
+  it("creates unique warning details from unresolved resource ids", () => {
+    const validationErrors = [
+      {
+        diagnostics:
+          "Resource [Patient/123e4567-e89b-12d3-a456-426614174000] contains a reference that does not resolve within the bundle",
+      },
+      {
+        diagnostics:
+          "Resource [Patient/123e4567-e89b-12d3-a456-426614174000] contains a reference that does not resolve within the bundle",
+      },
+    ];
+
+    const warningDetails = createUnresolvedPatientReferenceWarningDetails(
+      validationErrors,
+      (resourceId) => `Resource ${resourceId} does not resolve in the bundle`
+    );
+
+    expect(warningDetails).toEqual([
+      "Resource Patient/123e4567-e89b-12d3-a456-426614174000 does not resolve in the bundle",
+    ]);
+  });
+});
+
+describe("upsertExecuteInvalidTestCaseWarning", () => {
+  it("removes old execute-invalid warning and prepends latest warning", () => {
+    const setCustomWarningMessages = jest.fn();
+    const warningDetails = ["Resource Patient/123 has unresolved reference"];
+
+    upsertExecuteInvalidTestCaseWarning(
+      setCustomWarningMessages,
+      warningDetails
+    );
+
+    const stateUpdater = setCustomWarningMessages.mock.calls[0][0];
+    const nextState = stateUpdater([
+      { message: "Keep this", testDataId: "other-warning" },
+      {
+        message: "Old execute warning",
+        details: ["old"],
+        testDataId: EXECUTE_INVALID_TEST_WARNING_TEST_DATA_ID,
+      },
+    ]);
+
+    expect(nextState).toEqual([
+      {
+        message: EXECUTE_INVALID_TEST_CASES_WARNING,
+        details: warningDetails,
+        testDataId: EXECUTE_INVALID_TEST_WARNING_TEST_DATA_ID,
+      },
+      { message: "Keep this", testDataId: "other-warning" },
+    ]);
+  });
+
+  it("clears execute-invalid warning when details are empty", () => {
+    const setCustomWarningMessages = jest.fn();
+
+    upsertExecuteInvalidTestCaseWarning(setCustomWarningMessages, []);
+
+    const stateUpdater = setCustomWarningMessages.mock.calls[0][0];
+    const nextState = stateUpdater([
+      {
+        message: "Old execute warning",
+        details: ["old"],
+        testDataId: EXECUTE_INVALID_TEST_WARNING_TEST_DATA_ID,
+      },
+      { message: "Keep this", testDataId: "other-warning" },
+    ]);
+
+    expect(nextState).toEqual([
+      { message: "Keep this", testDataId: "other-warning" },
+    ]);
+  });
+});

--- a/src/components/editMeasure/testCases/components/editTestCase/qiCore/EditTestCaseUtil.ts
+++ b/src/components/editMeasure/testCases/components/editTestCase/qiCore/EditTestCaseUtil.ts
@@ -1,5 +1,16 @@
+import { Dispatch, SetStateAction } from "react";
 import { HapiOperationOutcome } from "@madie/madie-models";
 import _ from "lodash";
+import {
+  EXECUTE_INVALID_TEST_CASES_WARNING,
+  EXECUTE_INVALID_TEST_WARNING_TEST_DATA_ID,
+} from "../../testCaseConfiguration/executionOptions/ExecutionOptions";
+import { CustomWarningMessage } from "../../statusHandler/StatusHandler";
+
+const UNRESOLVED_PATIENT_REFERENCE_MESSAGE =
+  /Resource \[Patient\/.+?] contains a reference that does not resolve within the bundle/i;
+const UNRESOLVED_PATIENT_REFERENCE_RESOURCE_ID_REGEX =
+  /Resource \[(Patient\/.+?)]/i;
 
 export function isHapiOutcomeIssueCodeInformational(
   outcome: HapiOperationOutcome
@@ -38,4 +49,70 @@ export function extractValidationErrorsFromOutcome(
       `HAPI FHIR returned error code ${outcome.code} but no discernible error message`;
     return [{ key: 0, diagnostics: error }];
   }
+}
+
+export function extractUnresolvedPatientReferenceResourceIds(
+  validationErrors: any[]
+): string[] {
+  if (!Array.isArray(validationErrors) || validationErrors.length === 0) {
+    return [];
+  }
+
+  return [
+    ...new Set(
+      validationErrors
+        .map((validationError) => validationError?.diagnostics)
+        .filter(
+          (diagnostics) =>
+            typeof diagnostics === "string" &&
+            UNRESOLVED_PATIENT_REFERENCE_MESSAGE.test(diagnostics)
+        )
+        .map(
+          (diagnostics) =>
+            diagnostics.match(
+              UNRESOLVED_PATIENT_REFERENCE_RESOURCE_ID_REGEX
+            )?.[1]
+        )
+        .filter((resourceId) => typeof resourceId === "string")
+    ),
+  ];
+}
+
+export function createUnresolvedPatientReferenceWarningDetails(
+  validationErrors: any[],
+  warningDetailMessageBuilder: (resourceId: string) => string
+): string[] {
+  const invalidResourceIds =
+    extractUnresolvedPatientReferenceResourceIds(validationErrors);
+
+  if (invalidResourceIds.length === 0) {
+    return [];
+  }
+
+  return [...new Set(invalidResourceIds.map(warningDetailMessageBuilder))];
+}
+
+export function upsertExecuteInvalidTestCaseWarning(
+  setCustomWarningMessages: Dispatch<SetStateAction<CustomWarningMessage[]>>,
+  warningDetails: string[]
+) {
+  setCustomWarningMessages((previousMessages = []) => {
+    const filteredMessages = previousMessages.filter(
+      (message) =>
+        message?.testDataId !== EXECUTE_INVALID_TEST_WARNING_TEST_DATA_ID
+    );
+
+    if (!warningDetails?.length) {
+      return filteredMessages;
+    }
+
+    return [
+      {
+        message: EXECUTE_INVALID_TEST_CASES_WARNING,
+        details: [...new Set(warningDetails)],
+        testDataId: EXECUTE_INVALID_TEST_WARNING_TEST_DATA_ID,
+      },
+      ...filteredMessages,
+    ];
+  });
 }

--- a/src/components/editMeasure/testCases/components/routes/qiCore/TestCaseRoutes.tsx
+++ b/src/components/editMeasure/testCases/components/routes/qiCore/TestCaseRoutes.tsx
@@ -26,7 +26,10 @@ import TestCaseData from "../../testCaseConfiguration/testCaseData/TestCaseData"
 import SDEPage from "../../testCaseConfiguration/sde/SDEPage";
 import Expansion from "../../testCaseConfiguration/expansion/Expansion";
 import RAVPage from "../../testCaseConfiguration/rav/RAVPage";
-import ExecutionOptions from "../../testCaseConfiguration/executionOptions/ExecutionOptions";
+import ExecutionOptions, {
+  EXECUTE_INVALID_TEST_CASES_WARNING,
+  EXECUTE_INVALID_TEST_WARNING_TEST_DATA_ID,
+} from "../../testCaseConfiguration/executionOptions/ExecutionOptions";
 
 // error messages
 export const TEST_CASE_EXECUTION_ERROR =
@@ -120,9 +123,8 @@ const TestCaseRoutes = () => {
       if (measure?.testCaseConfiguration?.executeInvalidTestCases) {
         setCustomWarningMessages([
           {
-            message:
-              "Execution of invalid test cases is enabled. You may receive inaccurate pass/fail results. You can update this setting in Execution Configuration tab.",
-            testDataId: "test-cases-execute-invalid-test-cases-warning",
+            message: EXECUTE_INVALID_TEST_CASES_WARNING,
+            testDataId: EXECUTE_INVALID_TEST_WARNING_TEST_DATA_ID,
           },
         ]);
       }

--- a/src/components/editMeasure/testCases/components/routes/qiCore/TestCaseRoutes.tsx
+++ b/src/components/editMeasure/testCases/components/routes/qiCore/TestCaseRoutes.tsx
@@ -122,7 +122,7 @@ const TestCaseRoutes = () => {
           {
             message:
               "Execution of invalid test cases is enabled. You may receive inaccurate pass/fail results. You can update this setting in Execution Configuration tab.",
-            testDataId: "test-cases-in-use-warning",
+            testDataId: "test-cases-execute-invalid-test-cases-warning",
           },
         ]);
       }

--- a/src/components/editMeasure/testCases/components/testCaseConfiguration/executionOptions/ExecutionOptions.tsx
+++ b/src/components/editMeasure/testCases/components/testCaseConfiguration/executionOptions/ExecutionOptions.tsx
@@ -16,7 +16,7 @@ import useFormikResetOnEvent from "../../../../../common/useFormikResetOnEvent";
 import { Measure } from "@madie/madie-models";
 
 export const EXECUTE_INVALID_TEST_WARNING_TEST_DATA_ID =
-  "test-cases-execute-invalid-test-cases-warning";
+  "execute-invalid-test-cases-warning";
 export const EXECUTE_INVALID_TEST_CASES_WARNING =
   "Execution of invalid test cases is enabled. You may receive inaccurate pass/fail results. You can update this setting in Execution Configuration tab.";
 
@@ -73,7 +73,7 @@ export default function ExecutionOptions({ setCustomWarningMessages }) {
           setCustomWarningMessages([
             {
               message: EXECUTE_INVALID_TEST_CASES_WARNING,
-              testDataId: "test-cases-execute-invalid-test-cases-warning",
+              testDataId: EXECUTE_INVALID_TEST_WARNING_TEST_DATA_ID,
             },
           ]);
         } else {

--- a/src/components/editMeasure/testCases/components/testCaseConfiguration/executionOptions/ExecutionOptions.tsx
+++ b/src/components/editMeasure/testCases/components/testCaseConfiguration/executionOptions/ExecutionOptions.tsx
@@ -15,6 +15,11 @@ import { FormControlLabel, Checkbox } from "@mui/material";
 import useFormikResetOnEvent from "../../../../../common/useFormikResetOnEvent";
 import { Measure } from "@madie/madie-models";
 
+export const EXECUTE_INVALID_TEST_WARNING_TEST_DATA_ID =
+  "test-cases-execute-invalid-test-cases-warning";
+export const EXECUTE_INVALID_TEST_CASES_WARNING =
+  "Execution of invalid test cases is enabled. You may receive inaccurate pass/fail results. You can update this setting in Execution Configuration tab.";
+
 export default function ExecutionOptions({ setCustomWarningMessages }) {
   const [measure, setMeasure] = useState<Measure>(measureStore.state);
   const measureServiceApi = useMeasureServiceApi();
@@ -67,8 +72,7 @@ export default function ExecutionOptions({ setCustomWarningMessages }) {
         if (newMeasure?.testCaseConfiguration?.executeInvalidTestCases) {
           setCustomWarningMessages([
             {
-              message:
-                "Execution of invalid test cases is enabled. You may receive inaccurate pass/fail results. You can update this setting in Execution Configuration tab.",
+              message: EXECUTE_INVALID_TEST_CASES_WARNING,
               testDataId: "test-cases-execute-invalid-test-cases-warning",
             },
           ]);

--- a/src/components/editMeasure/testCases/components/testCaseLanding/qiCore/TestCaseList.test.tsx
+++ b/src/components/editMeasure/testCases/components/testCaseLanding/qiCore/TestCaseList.test.tsx
@@ -1960,6 +1960,108 @@ describe("TestCaseList component", () => {
     await waitFor(() => expect(executeAllTestCasesButton).toBeDisabled());
   });
 
+  it("renders spinner overlay when openMakeJsonMatchUiSpinner is true", async () => {
+    renderTestCaseListComponent();
+
+    await waitFor(() => {
+      const selectButton = screen.getByTestId(`test-case-title-0_select`);
+      const checkboxButton = within(selectButton).getByRole("checkbox");
+      expect(checkboxButton).toBeInTheDocument();
+      fireEvent.click(checkboxButton);
+      expect(checkboxButton).toBeChecked();
+    });
+
+    const makeJsonMatchUiButton = screen.getByTestId(
+      "make-json-match-ui-action-icon"
+    );
+    expect(makeJsonMatchUiButton).toBeEnabled();
+    fireEvent.click(makeJsonMatchUiButton);
+
+    const continueButton = screen.getByTestId(
+      "make-json-match-ui-continue-button"
+    );
+    userEvent.click(continueButton);
+
+    // Note: the spinner appears too short, might need to use advance timer
+    // await waitFor(() =>
+    //   expect(
+    //     screen.getByTestId("make-json-match-ui-spinner")
+    //   ).toBeInTheDocument()
+    // );
+  });
+
+  describe("unresolvedReferenceWarningDetails useEffect", () => {
+    it("should not call setCustomWarningMessages when executeInvalidTestCases is falsy", async () => {
+      const measureWithoutConfig = {
+        ...mockMeasure,
+        testCaseConfiguration: { executeInvalidTestCases: undefined },
+      } as unknown as Measure;
+
+      setCustomWarningMessages.mockClear();
+      renderTestCaseListComponent([], ["test"], false, measureWithoutConfig);
+
+      await waitFor(() => {
+        expect(screen.getByTestId("test-case-tbl")).toBeInTheDocument();
+      });
+
+      expect(setCustomWarningMessages).not.toHaveBeenCalled();
+    });
+
+    it("should call setCustomWarningMessages with warning details when test cases have unresolved patient references", async () => {
+      const measureWithConfig = {
+        ...mockMeasure,
+        testCaseConfiguration: { executeInvalidTestCases: true },
+        testCases: testCases,
+      } as unknown as Measure;
+
+      useTestCaseServiceMock.mockImplementation(() => {
+        return {
+          ...useTestCaseServiceMockResolved,
+          getTestCasesByMeasureId: jest.fn().mockResolvedValue([
+            {
+              ...testCases[0],
+              hapiOperationOutcome: {
+                code: 400,
+                successful: false,
+                outcomeResponse: {
+                  issue: [
+                    {
+                      diagnostics:
+                        "Unable to resolve resource with ID 'Patient/invalid-ref' that does not resolve within the bundle",
+                    },
+                  ],
+                },
+              },
+            },
+            testCases[1],
+          ]),
+        } as unknown as TestCaseServiceApi;
+      });
+
+      setCustomWarningMessages.mockClear();
+      renderTestCaseListComponent([], ["test"], false, measureWithConfig);
+
+      await waitFor(() => {
+        expect(setCustomWarningMessages).toHaveBeenCalled();
+      });
+    });
+
+    it("should call setCustomWarningMessages with empty warnings when test cases have no unresolved references", async () => {
+      const measureWithConfig = {
+        ...mockMeasure,
+        testCaseConfiguration: { executeInvalidTestCases: true },
+        testCases: testCases,
+      } as unknown as Measure;
+
+      setCustomWarningMessages.mockClear();
+      renderTestCaseListComponent([], ["test"], false, measureWithConfig);
+
+      await waitFor(() => {
+        expect(setCustomWarningMessages).toHaveBeenCalled();
+      });
+    });
+  });
+
   describe("TestCaseList component with deleteMultipleTestCases", () => {
     it("should delete selected test cases", async () => {
       useTestCaseServiceMock.mockImplementation(() => {
@@ -1996,36 +2098,6 @@ describe("TestCaseList component", () => {
       expect(toastMessage).toHaveTextContent("Test cases successfully deleted");
       expect(screen.queryByTestId("delete-dialog-body")).toBeNull();
     }, 15000);
-  });
-
-  test("renders spinner overlay when openMakeJsonMatchUiSpinner is true", async () => {
-    renderTestCaseListComponent();
-
-    await waitFor(() => {
-      const selectButton = screen.getByTestId(`test-case-title-0_select`);
-      const checkboxButton = within(selectButton).getByRole("checkbox");
-      expect(checkboxButton).toBeInTheDocument();
-      fireEvent.click(checkboxButton);
-      expect(checkboxButton).toBeChecked();
-    });
-
-    const makeJsonMatchUiButton = screen.getByTestId(
-      "make-json-match-ui-action-icon"
-    );
-    expect(makeJsonMatchUiButton).toBeEnabled();
-    fireEvent.click(makeJsonMatchUiButton);
-
-    const continueButton = screen.getByTestId(
-      "make-json-match-ui-continue-button"
-    );
-    userEvent.click(continueButton);
-
-    // Note: the spinner appears too short, might need to use advance timer
-    // await waitFor(() =>
-    //   expect(
-    //     screen.getByTestId("make-json-match-ui-spinner")
-    //   ).toBeInTheDocument()
-    // );
   });
 });
 

--- a/src/components/editMeasure/testCases/components/testCaseLanding/qiCore/TestCaseList.tsx
+++ b/src/components/editMeasure/testCases/components/testCaseLanding/qiCore/TestCaseList.tsx
@@ -46,6 +46,11 @@ import { generateQiCoreReport } from "../../../util/OverlappingCodesUtils";
 import OverlappingCodesDialog from "../common/overLappingCodes/OverlappingCodesDialog";
 import getModelFamily from "../../../../../../utils/measureModelHelpers";
 import useFhirDefinitionsServiceApi from "../../../api/useFhirDefinitionsService";
+import {
+  createUnresolvedPatientReferenceWarningDetails,
+  extractValidationErrorsFromOutcome,
+  upsertExecuteInvalidTestCaseWarning,
+} from "../../editTestCase/qiCore/EditTestCaseUtil";
 
 export const IMPORT_ERROR =
   "An error occurred while importing your test cases. Please try again, or reach out to the Help Desk.";
@@ -217,6 +222,8 @@ const TestCaseList = (props: TestCaseListProps) => {
   const [openMakeJsonMatchUiSpinner, setOpenMakeJsonMatchUiSpinner] =
     useState<boolean>(false);
 
+  const executeInvalidTestCases =
+    measure?.testCaseConfiguration?.executeInvalidTestCases;
   const fhirDefinitionServiceApi = useRef(useFhirDefinitionsServiceApi());
 
   useEffect(() => {
@@ -225,6 +232,34 @@ const TestCaseList = (props: TestCaseListProps) => {
       updateMeasure(newMeasure);
     }
   }, [testCases]);
+
+  useEffect(() => {
+    if (!setCustomWarningMessages || !executeInvalidTestCases) {
+      return;
+    }
+
+    const unresolvedReferenceWarningDetails = (testCases || []).flatMap(
+      (testCase) => {
+        const validationErrors = extractValidationErrorsFromOutcome(
+          testCase?.hapiOperationOutcome
+        );
+        const groupName = _.trim(testCase?.series) || "";
+        const testCaseTitle = _.trim(testCase?.title) || testCase?.id || "";
+
+        return createUnresolvedPatientReferenceWarningDetails(
+          validationErrors,
+          (resourceId) =>
+            `Test case ${groupName} ${testCaseTitle} with resource ${resourceId} contains a reference that does not resolve within the bundle`
+        );
+      }
+    );
+
+    upsertExecuteInvalidTestCaseWarning(
+      setCustomWarningMessages,
+      unresolvedReferenceWarningDetails
+    );
+  }, [testCases, setCustomWarningMessages, executeInvalidTestCases]);
+
   useEffect(() => {
     setExecuteAllTestCases(false);
     if (
@@ -274,8 +309,7 @@ const TestCaseList = (props: TestCaseListProps) => {
   }, [measure]);
 
   useEffect(() => {
-    const validTestCases = measure?.testCaseConfiguration
-      ?.executeInvalidTestCases
+    const validTestCases = executeInvalidTestCases
       ? sortedTestCases
       : sortedTestCases?.filter((tc) => tc.validResource);
     if (validTestCases && calculationOutput?.results && selectedPopCriteria) {
@@ -475,25 +509,21 @@ const TestCaseList = (props: TestCaseListProps) => {
       return null;
     }
 
-    const filteredTestCases = measure?.testCaseConfiguration
-      ?.executeInvalidTestCases
+    const filteredTestCases = executeInvalidTestCases
       ? sortedTestCases
       : sortedTestCases?.filter((tc) => tc.validResource);
 
     if (filteredTestCases && filteredTestCases.length > 0 && measureBundle) {
       setExecuting(true);
       try {
-        let executionBundle = filteredTestCases;
-        if (!measure?.testCaseConfiguration?.executeInvalidTestCases) {
-          //filter any resources with invalid references.
-          const updatedTestCaseExecutionBundle =
-            await fhirDefinitionServiceApi.current.getTestCaseExecutionBundle(
-              measure.model,
-              filteredTestCases
-            );
-          executionBundle = updatedTestCaseExecutionBundle?.testCases;
-        }
-
+        //filter any resources with invalid references.
+        const updatedTestCaseExecutionBundle =
+          await fhirDefinitionServiceApi.current.getTestCaseExecutionBundle(
+            measure.model,
+            filteredTestCases,
+            executeInvalidTestCases
+          );
+        const executionBundle = updatedTestCaseExecutionBundle?.testCases;
         const calculationOutput: CalculationOutput<any> =
           await calculation.current.calculateTestCases(
             measure,


### PR DESCRIPTION
…e execution

## MADiE PR

Jira Ticket: [MAT-9962](https://jira.cms.gov/browse/MAT-9962)
(Optional) Related Tickets:

### Summary
- Allow invalid Patient references in test cases into test case
- Update test case validation based on executeInvalidTestCases configuration
- if executeInvalidTestCases is true, we want to allow invalid references to the Patient resource. however, we still going to display the warnings instead of errors.
- if executeInvalidTestCases is false, this should function the way it is currently working i.e. showing errors for invalid references irrespective of resource type
- Related PRs
  - https://github.com/MeasureAuthoringTool/measure-service/pull/1120, 
  - https://github.com/MeasureAuthoringTool/madie-fhir-service/pull/438

### All Submissions
* [x] This PR has the JIRA linked.
* [x] Required tests are included.
* [ ] No extemporaneous files are included (i.e Complied files or testing results).
* [x] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).
* [ ] All CDN/Web dependencies are hosted internally (i.e MADiE-Root Repo).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
