### PR TITLE
MAT-10080: Replace "Select Profile(s)" with "View Test Case" and "Insert" buttons

### DIFF
--- a/src/components/editMeasure/testCases/components/editTestCase/qiCore/EditCompositeTestCase/CompositeLeftPanelContent.tsx
+++ b/src/components/editMeasure/testCases/components/editTestCase/qiCore/EditCompositeTestCase/CompositeLeftPanelContent.tsx
@@ -16,6 +16,7 @@ import _ from "lodash";
 import useExecutionContext from "../../../routes/qiCore/useExecutionContext";
 import { useQiCoreResource } from "../../../../util/QiCorePatientProvider";
 import CompositeProfileViews from "./CompositeProfilesViews";
+import ViewTestCaseModal from "./ViewTestCaseModal";
 
 const CompositeLeftPanelContent = ({
   leftPanelActiveTab,
@@ -35,6 +36,8 @@ const CompositeLeftPanelContent = ({
   const [loadingTestCases, setLoadingTestCases] = useState(false);
   const [completedMeasureCount, setCompletedMeasureCount] = useState(0);
   const [howItWorksOpen, setHowItWorksOpen] = useState<boolean>(false);
+  const [viewTestCaseModalOpen, setViewTestCaseModalOpen] =
+    useState<boolean>(false);
 
   // builder utilities for available elements tab
   const [resources, setResources] = useState<ResourceIdentifier[]>([]);
@@ -43,6 +46,9 @@ const CompositeLeftPanelContent = ({
   // const [resourceIdentifiers, setResourceIdentifiers] = useState([]); // likely needed later when readding features
   const fhirElmTranslationService = useRef(useFhirElmTranslationServiceApi());
   const [selectedResourceID, setSelectedResourceId] = useState<string>(null); // one single source of truth.
+  const [selectedTestCase, setSelectedTestCase] = useState<TestCase | null>(
+    null
+  );
   const { measureState } = useExecutionContext();
   const { state, dispatch } = useQiCoreResource();
   const [measure] = measureState;
@@ -134,6 +140,11 @@ const CompositeLeftPanelContent = ({
     setTestCases([]);
   };
 
+  const handleViewTestCase = (testCase: TestCase) => {
+    setSelectedTestCase(testCase);
+    setViewTestCaseModalOpen(true);
+  };
+
   return (
     <>
       <div className="tab-container">
@@ -183,6 +194,7 @@ const CompositeLeftPanelContent = ({
                     testCases={testCases}
                     selectedMeasure={selectedMeasure}
                     onBackToMeasures={handleBackToMeasures}
+                    onViewTestCase={handleViewTestCase}
                   />
                 ) : (
                   <>
@@ -225,6 +237,11 @@ const CompositeLeftPanelContent = ({
           height="100%"
         />
       )}
+      <ViewTestCaseModal
+        open={viewTestCaseModalOpen}
+        onClose={() => setViewTestCaseModalOpen(false)}
+        testCase={selectedTestCase}
+      />
     </>
   );
 };

--- a/src/components/editMeasure/testCases/components/editTestCase/qiCore/EditCompositeTestCase/CompositeTestCasesTable.test.tsx
+++ b/src/components/editMeasure/testCases/components/editTestCase/qiCore/EditCompositeTestCase/CompositeTestCasesTable.test.tsx
@@ -65,7 +65,8 @@ describe("CompositeTestCasesTable", () => {
     testCases,
     selectedMeasure: mockMeasure,
     onBackToMeasures: jest.fn(),
-    onSelectProfile: jest.fn(),
+    onViewTestCase: jest.fn(),
+    onInsertTestCase: jest.fn(),
   };
 
   beforeEach(() => {
@@ -81,7 +82,7 @@ describe("CompositeTestCasesTable", () => {
     expect(screen.getByTestId("back-to-measures-btn")).toBeInTheDocument();
     expect(
       screen.getByText(
-        "2. Select which Test Case to choose Test Case Profiles from:"
+        "2. Select which Test Case to insert into composite test case:"
       )
     ).toBeInTheDocument();
     expect(screen.getByText("My Composite Measure")).toBeInTheDocument();
@@ -139,11 +140,32 @@ describe("CompositeTestCasesTable", () => {
     expect(defaultProps.onBackToMeasures).toHaveBeenCalledTimes(1);
   });
 
-  it("calls onSelectProfile with the correct test case", () => {
+  it("calls onViewTestCase with the correct test case", () => {
     render(<CompositeTestCasesTable {...defaultProps} />);
-    fireEvent.click(screen.getByTestId("select-profile-btn-tc2"));
-    expect(defaultProps.onSelectProfile).toHaveBeenCalledWith(
+    fireEvent.click(screen.getByTestId("view-test-case-btn-tc2"));
+    expect(defaultProps.onViewTestCase).toHaveBeenCalledWith(
       expect.objectContaining({ id: "tc2", title: "Test Case Beta" })
+    );
+  });
+
+  it("calls onInsertTestCase with the correct test case", () => {
+    render(<CompositeTestCasesTable {...defaultProps} />);
+    fireEvent.click(screen.getByTestId("insert-test-case-btn-tc2"));
+    expect(defaultProps.onInsertTestCase).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "tc2", title: "Test Case Beta" })
+    );
+  });
+
+  it("renders title attributes for view and insert action buttons", () => {
+    render(<CompositeTestCasesTable {...defaultProps} />);
+
+    expect(screen.getByTestId("view-test-case-btn-tc1")).toHaveAttribute(
+      "title",
+      "View test case"
+    );
+    expect(screen.getByTestId("insert-test-case-btn-tc1")).toHaveAttribute(
+      "title",
+      "Insert test case"
     );
   });
 

--- a/src/components/editMeasure/testCases/components/editTestCase/qiCore/EditCompositeTestCase/CompositeTestCasesTable.tsx
+++ b/src/components/editMeasure/testCases/components/editTestCase/qiCore/EditCompositeTestCase/CompositeTestCasesTable.tsx
@@ -36,12 +36,14 @@ export default function CompositeTestCasesTable({
   testCases,
   selectedMeasure,
   onBackToMeasures,
-  onSelectProfile,
+  onViewTestCase,
+  onInsertTestCase,
 }: {
   testCases: TestCase[];
   selectedMeasure: Measure;
   onBackToMeasures: () => void;
-  onSelectProfile?: (testCase: TestCase) => void;
+  onViewTestCase?: (testCase: TestCase) => void;
+  onInsertTestCase?: (testCase: TestCase) => void;
 }) {
   const [howItWorksOpen, setHowItWorksOpen] = useState<boolean>(false);
   const [hoveredHeader, setHoveredHeader] = useState<string>("");
@@ -153,21 +155,34 @@ export default function CompositeTestCasesTable({
         header: null,
         size: 15,
         cell: (info) => (
-          <Button
-            tw="m-2"
-            type="button"
-            data-testid={`select-profile-btn-${info.row.original.id}`}
-            onClick={() => onSelectProfile?.(info.row.original)}
-          >
-            Select Profile(s)
-            <ChevronRightIcon style={{ height: "20px", width: "20px" }} />
-          </Button>
+          <>
+            <Button
+              tw="m-2"
+              type="button"
+              title="View test case"
+              data-testid={`view-test-case-btn-${info.row.original.id}`}
+              onClick={() => onViewTestCase?.(info.row.original)}
+            >
+              View Test Case
+            </Button>
+            <Button
+              tw="m-2"
+              type="button"
+              title="Insert test case"
+              data-testid={`insert-test-case-btn-${info.row.original.id}`}
+              disabled={!validTestCases.includes(info.row.original)}
+              onClick={() => onInsertTestCase?.(info.row.original)}
+            >
+              Insert
+              <ChevronRightIcon style={{ height: "20px", width: "20px" }} />
+            </Button>
+          </>
         ),
         accessorKey: "actions",
         enableSorting: false,
       },
     ],
-    [onSelectProfile]
+    [onViewTestCase, onInsertTestCase, validTestCases]
   );
 
   const table = useReactTable({
@@ -240,7 +255,7 @@ export default function CompositeTestCasesTable({
 
       {/* Header */}
       <h3 style={{ fontSize: 18, fontWeight: 500 }}>
-        2. Select which Test Case to choose Test Case Profiles from:
+        2. Select which Test Case to insert into composite test case:
       </h3>
       <hr
         style={{

--- a/src/components/editMeasure/testCases/components/editTestCase/qiCore/EditCompositeTestCase/ViewTestCaseModal.test.tsx
+++ b/src/components/editMeasure/testCases/components/editTestCase/qiCore/EditCompositeTestCase/ViewTestCaseModal.test.tsx
@@ -1,0 +1,127 @@
+import * as React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+import ViewTestCaseModal from "./ViewTestCaseModal";
+
+jest.mock("../../../editor/Editor", () => ({
+  __esModule: true,
+  default: ({ value, readOnly }: any) => (
+    <textarea data-testid="json-editor" value={value} readOnly={readOnly} />
+  ),
+}));
+
+jest.mock("../LeftPanel/ElementsTab/ElementsTab", () => ({
+  __esModule: true,
+  default: (props: any) => (
+    <div
+      data-testid="elements-tab-mock"
+      data-active-tab={props.activeTab}
+      data-can-edit={String(props.canEdit)}
+    />
+  ),
+}));
+
+jest.mock("../../../../util/QiCorePatientProvider", () => ({
+  __esModule: true,
+  QiCoreResourceProvider: ({ children }: any) => <>{children}</>,
+}));
+
+jest.mock("../../calculator/CalculatorDialog", () => ({
+  __esModule: true,
+  default: ({ open }: any) =>
+    open ? <div data-testid="calculator-dialog-mock" /> : null,
+}));
+
+jest.mock("../../calculator/EditorCalculator", () => ({
+  __esModule: true,
+  default: ({ onClick }: any) => (
+    <button data-testid="editor-calculator-button" onClick={onClick}>
+      Calculator
+    </button>
+  ),
+}));
+
+jest.mock("../LeftPanel/EditorSearch", () => ({
+  __esModule: true,
+  default: () => <div data-testid="editor-search-mock" />,
+}));
+
+const testCase = {
+  id: "tc-1",
+  title: "Test Case Alpha",
+  json: JSON.stringify({ resourceType: "Bundle", entry: [{}, {}] }),
+} as any;
+
+describe("ViewTestCaseModal", () => {
+  it("renders shared left-panel tabs with added and json states", () => {
+    render(
+      <ViewTestCaseModal open={true} onClose={jest.fn()} testCase={testCase} />
+    );
+
+    expect(screen.getByText("Added (2)")).toBeInTheDocument();
+    expect(screen.getByText("JSON")).toBeInTheDocument();
+    expect(screen.queryByTestId("available-tab")).not.toBeInTheDocument();
+    expect(screen.getByTestId("elements-tab-mock")).toHaveAttribute(
+      "data-active-tab",
+      "added"
+    );
+  });
+
+  it("switches to json and exposes json search", async () => {
+    render(
+      <ViewTestCaseModal open={true} onClose={jest.fn()} testCase={testCase} />
+    );
+
+    await userEvent.click(screen.getByText("JSON"));
+
+    expect(screen.getByTestId("json-editor")).toBeInTheDocument();
+    expect(screen.getByTestId("editor-search-mock")).toBeInTheDocument();
+  });
+
+  it("opens calculator dialog from the shared tabs", async () => {
+    render(
+      <ViewTestCaseModal open={true} onClose={jest.fn()} testCase={testCase} />
+    );
+
+    await userEvent.click(screen.getByTestId("editor-calculator-button"));
+
+    expect(screen.getByTestId("calculator-dialog-mock")).toBeInTheDocument();
+  });
+
+  it("uses an empty string when test case json is undefined", async () => {
+    const undefinedJsonTestCase = {
+      ...testCase,
+      json: undefined,
+    } as any;
+
+    render(
+      <ViewTestCaseModal
+        open={true}
+        onClose={jest.fn()}
+        testCase={undefinedJsonTestCase}
+      />
+    );
+
+    await userEvent.click(screen.getByText("JSON"));
+
+    expect(screen.getByTestId("json-editor")).toHaveValue("");
+  });
+
+  it("uses an empty string when JSON.stringify throws", async () => {
+    const stringifySpy = jest
+      .spyOn(JSON, "stringify")
+      .mockImplementationOnce(() => {
+        throw new Error("stringify failed");
+      });
+
+    render(
+      <ViewTestCaseModal open={true} onClose={jest.fn()} testCase={testCase} />
+    );
+
+    await userEvent.click(screen.getByText("JSON"));
+
+    expect(screen.getByTestId("json-editor")).toHaveValue("");
+    stringifySpy.mockRestore();
+  });
+});

--- a/src/components/editMeasure/testCases/components/editTestCase/qiCore/EditCompositeTestCase/ViewTestCaseModal.tsx
+++ b/src/components/editMeasure/testCases/components/editTestCase/qiCore/EditCompositeTestCase/ViewTestCaseModal.tsx
@@ -1,0 +1,149 @@
+import React, { useEffect, useState } from "react";
+import { useFormik, FormikProvider } from "formik";
+import { MadieDialog } from "@madie/madie-design-system/dist/react";
+import { DialogContent } from "@mui/material";
+import { TestCase } from "@madie/madie-models";
+import Editor from "../../../editor/Editor";
+import ElementsTab from "../LeftPanel/ElementsTab/ElementsTab";
+import CreateTestCaseLeftPanelNavTabs from "../../../createTestCase/CreateTestCaseLeftPanelNavTabs";
+import CalculatorDialog from "../../calculator/CalculatorDialog";
+import { QiCoreResourceProvider } from "../../../../util/QiCorePatientProvider";
+
+interface ViewTestCaseModalProps {
+  open: boolean;
+  onClose: () => void;
+  testCase: TestCase | null;
+}
+
+function standardizeJson(json: string | undefined | null): string {
+  if (!json) {
+    return "";
+  }
+
+  try {
+    return JSON.stringify(JSON.parse(json), null, 2);
+  } catch (error) {
+    return "";
+  }
+}
+
+function getAddedCount(json: string): number {
+  if (!json) {
+    return 0;
+  }
+
+  try {
+    const bundle = JSON.parse(json);
+    return Array.isArray(bundle?.entry) ? bundle.entry.length : 0;
+  } catch (error) {
+    return 0;
+  }
+}
+
+export default function ViewTestCaseModal({
+  open,
+  onClose,
+  testCase,
+}: ViewTestCaseModalProps) {
+  const [activeTab, setActiveTab] = useState<"added" | "json">("added");
+  const [editorVal, setEditorVal] = useState<string>("");
+  const [calculationDialogOpen, setCalculationDialogOpen] =
+    useState<boolean>(false);
+  const [validationSchema, setValidationSchema] = useState({});
+  const [initialFormikValuesStu6, setInitialFormikValuesStu6] = useState({});
+
+  const formikStu6Context = useFormik({
+    initialValues: initialFormikValuesStu6,
+    enableReinitialize: true,
+    validationSchema,
+    onSubmit: () => {},
+  });
+
+  useEffect(() => {
+    if (!open) {
+      setCalculationDialogOpen(false);
+      return;
+    }
+
+    setActiveTab("added");
+    setEditorVal(standardizeJson(testCase?.json));
+  }, [open, testCase]);
+
+  return (
+    <MadieDialog
+      title={
+        testCase?.title ? `View Test Case: ${testCase.title}` : "View Test Case"
+      }
+      dialogProps={{
+        open,
+        onClose,
+        maxWidth: "lg",
+        fullWidth: true,
+      }}
+      cancelButtonProps={{
+        cancelText: "Close",
+        "data-testid": "view-test-case-modal-close-button",
+      }}
+      continueButtonProps={""}
+    >
+      <DialogContent>
+        <div data-testid="view-test-case-modal" style={{ minHeight: 480 }}>
+          <div className="nav-panel">
+            <div
+              className="tab-container"
+              style={{
+                backgroundColor: "#ededed",
+                display: "flex",
+                flexDirection: "row",
+                alignItems: "center",
+              }}
+            >
+              <CreateTestCaseLeftPanelNavTabs
+                leftPanelActiveTab={activeTab}
+                setLeftPanelActiveTab={(value) =>
+                  setActiveTab(value as "added" | "json")
+                }
+                isQICore6={true}
+                dirty={false}
+                setCalculationDialogOpen={setCalculationDialogOpen}
+                canEdit={false}
+                addedCount={getAddedCount(editorVal)}
+              />
+            </div>
+
+            {activeTab === "added" ? (
+              <div data-testid="view-test-case-added-panel">
+                <FormikProvider value={formikStu6Context}>
+                  <QiCoreResourceProvider>
+                    <ElementsTab
+                      setValidationSchema={setValidationSchema}
+                      setInitialFormikValuesStu6={setInitialFormikValuesStu6}
+                      setEditorVal={setEditorVal}
+                      canEdit={false}
+                      editorVal={editorVal}
+                      testCase={testCase}
+                      activeTab="added"
+                    />
+                  </QiCoreResourceProvider>
+                </FormikProvider>
+              </div>
+            ) : (
+              <div data-testid="view-test-case-json-panel">
+                <Editor
+                  onChange={(val: string) => setEditorVal(val)}
+                  value={editorVal}
+                  readOnly={true}
+                  height="480px"
+                />
+              </div>
+            )}
+          </div>
+        </div>
+      </DialogContent>
+      <CalculatorDialog
+        open={calculationDialogOpen}
+        onClose={() => setCalculationDialogOpen(false)}
+      />
+    </MadieDialog>
+  );
+}


### PR DESCRIPTION
## MADiE PR

Jira Ticket: [MAT-10080](https://jira.cms.gov/browse/MAT-10080)
(Optional) Related Tickets:

### Summary

On the Test Case selector UI for composite measures, replace the "Select Profile(s)" button with "View Test Case" and "Insert".

On click of "View Test Case", display a modal of the read-only "Added" profiles and "JSON" tabs. This is accomplished by mimicking the existing tab UI in a custom component. 

### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included.
* [ ] No extemporaneous files are included (i.e Complied files or testing results).
* [ ] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).
* [ ] All CDN/Web dependencies are hosted internally (i.e MADiE-Root Repo).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
