### PR TITLE
MAT-9977 dedup resources when switching between all resources and measure-relevant resources, display base fhir resources for All profile/resources option

### DIFF
--- a/src/components/editMeasure/testCases/components/editTestCase/qiCore/LeftPanel/ElementsTab/builder/Builder.test.tsx
+++ b/src/components/editMeasure/testCases/components/editTestCase/qiCore/LeftPanel/ElementsTab/builder/Builder.test.tsx
@@ -774,49 +774,55 @@ describe("deduplicateAndSortResources", () => {
     title: "QICore Patient",
     type: "Patient",
     category: "Base",
-    profile: "profile-patient",
+    profile:
+      "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-patient",
   };
   const mockEncounter = {
     id: "qicore-encounter",
     title: "QICore Encounter",
     type: "Encounter",
     category: "Base",
-    profile: "profile-encounter",
+    profile:
+      "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter",
   };
   const mockAllergyIntolerance = {
     id: "qicore-allergyintolerance",
     title: "QICore AllergyIntolerance",
     type: "AllergyIntolerance",
     category: "Clinical",
-    profile: "profile-allergy",
+    profile:
+      "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-allergyintolerance",
   };
   const mockCondition = {
     id: "qicore-condition",
     title: "QICore Condition",
     type: "Condition",
     category: "Clinical",
-    profile: "profile-condition",
+    profile:
+      "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition",
   };
   const mockProcedure = {
     id: "qicore-procedure",
     title: "QICore Procedure",
     type: "Procedure",
     category: "Clinical",
-    profile: "profile-procedure",
+    profile:
+      "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedure",
   };
   const mockUsCoreCondition = {
     id: "us-core-condition",
     title: "US Core Condition",
     type: "Condition",
     category: "Clinical",
-    profile: "profile-us-core-condition",
+    profile:
+      "http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition",
   };
   const mockFhirObservation = {
     id: "fhir-observation",
     title: "FHIR Observation",
     type: "Observation",
     category: "Clinical",
-    profile: "profile-observation",
+    profile: "http://hl7.org/fhir/StructureDefinition/Observation",
   };
 
   it("should remove duplicate profiles", () => {

--- a/src/components/editMeasure/testCases/components/editTestCase/qiCore/LeftPanel/ElementsTab/builder/Builder.test.tsx
+++ b/src/components/editMeasure/testCases/components/editTestCase/qiCore/LeftPanel/ElementsTab/builder/Builder.test.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import Builder, {
   NO_PROFILES_MESSAGE,
   scrollToElementByIdWhenAvailable,
+  deduplicateAndSortResources,
 } from "./Builder";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
@@ -764,5 +765,113 @@ describe("scrollToElementByIdWhenAvailable", () => {
       "json-error-alert-duplicate-resource-ids"
     );
     expect(duplicateResourceError).toBeInTheDocument();
+  });
+});
+
+describe("deduplicateAndSortResources", () => {
+  const mockPatient = {
+    id: "qicore-patient",
+    title: "QICore Patient",
+    type: "Patient",
+    category: "Base",
+    profile: "profile-patient",
+  };
+  const mockEncounter = {
+    id: "qicore-encounter",
+    title: "QICore Encounter",
+    type: "Encounter",
+    category: "Base",
+    profile: "profile-encounter",
+  };
+  const mockAllergyIntolerance = {
+    id: "qicore-allergyintolerance",
+    title: "QICore AllergyIntolerance",
+    type: "AllergyIntolerance",
+    category: "Clinical",
+    profile: "profile-allergy",
+  };
+  const mockCondition = {
+    id: "qicore-condition",
+    title: "QICore Condition",
+    type: "Condition",
+    category: "Clinical",
+    profile: "profile-condition",
+  };
+  const mockProcedure = {
+    id: "qicore-procedure",
+    title: "QICore Procedure",
+    type: "Procedure",
+    category: "Clinical",
+    profile: "profile-procedure",
+  };
+  const mockUsCoreCondition = {
+    id: "us-core-condition",
+    title: "US Core Condition",
+    type: "Condition",
+    category: "Clinical",
+    profile: "profile-us-core-condition",
+  };
+  const mockFhirObservation = {
+    id: "fhir-observation",
+    title: "FHIR Observation",
+    type: "Observation",
+    category: "Clinical",
+    profile: "profile-observation",
+  };
+
+  it("should remove duplicate profiles", () => {
+    const input = [mockEncounter, mockEncounter, mockPatient];
+    const result = deduplicateAndSortResources(input);
+    expect(result).toHaveLength(2);
+    expect(result.map((r) => r.title)).toEqual([
+      "QICore Patient",
+      "QICore Encounter",
+    ]);
+  });
+
+  it("should place QICore Patient first regardless of alphabetical order", () => {
+    const input = [mockAllergyIntolerance, mockCondition, mockPatient];
+    const result = deduplicateAndSortResources(input);
+    expect(result[0].id).toBe("qicore-patient");
+  });
+
+  it("should filter out non-qicore and non-us-core resources", () => {
+    const input = [mockPatient, mockFhirObservation, mockUsCoreCondition];
+    const result = deduplicateAndSortResources(input);
+    expect(result).toHaveLength(2);
+    expect(result.map((r) => r.id)).toEqual([
+      "qicore-patient",
+      "us-core-condition",
+    ]);
+  });
+
+  it("should not produce duplicates when called multiple times with the same input", () => {
+    const input = [mockPatient, mockEncounter, mockEncounter];
+    // Simulate toggling between modes — calling the function multiple times
+    const result1 = deduplicateAndSortResources(input);
+    const result2 = deduplicateAndSortResources(input);
+    expect(result1).toEqual(result2);
+    expect(result1).toHaveLength(2);
+  });
+
+  it("should sort alphabetically (after placing Patient first)", () => {
+    const input = [
+      mockProcedure,
+      mockPatient,
+      mockAllergyIntolerance,
+      mockEncounter,
+    ];
+    const result = deduplicateAndSortResources(input);
+    expect(result.map((r) => r.title)).toEqual([
+      "QICore Patient",
+      "QICore AllergyIntolerance",
+      "QICore Encounter",
+      "QICore Procedure",
+    ]);
+  });
+
+  it("should handle empty input", () => {
+    const result = deduplicateAndSortResources([]);
+    expect(result).toEqual([]);
   });
 });

--- a/src/components/editMeasure/testCases/components/editTestCase/qiCore/LeftPanel/ElementsTab/builder/Builder.test.tsx
+++ b/src/components/editMeasure/testCases/components/editTestCase/qiCore/LeftPanel/ElementsTab/builder/Builder.test.tsx
@@ -840,16 +840,6 @@ describe("deduplicateAndSortResources", () => {
     expect(result[0].id).toBe("qicore-patient");
   });
 
-  it("should filter out non-qicore and non-us-core resources", () => {
-    const input = [mockPatient, mockFhirObservation, mockUsCoreCondition];
-    const result = deduplicateAndSortResources(input);
-    expect(result).toHaveLength(2);
-    expect(result.map((r) => r.id)).toEqual([
-      "qicore-patient",
-      "us-core-condition",
-    ]);
-  });
-
   it("should not produce duplicates when called multiple times with the same input", () => {
     const input = [mockPatient, mockEncounter, mockEncounter];
     // Simulate toggling between modes — calling the function multiple times

--- a/src/components/editMeasure/testCases/components/editTestCase/qiCore/LeftPanel/ElementsTab/builder/Builder.test.tsx
+++ b/src/components/editMeasure/testCases/components/editTestCase/qiCore/LeftPanel/ElementsTab/builder/Builder.test.tsx
@@ -774,8 +774,7 @@ describe("deduplicateAndSortResources", () => {
     title: "QICore Patient",
     type: "Patient",
     category: "Base",
-    profile:
-      "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-patient",
+    profile: "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-patient",
   };
   const mockEncounter = {
     id: "qicore-encounter",

--- a/src/components/editMeasure/testCases/components/editTestCase/qiCore/LeftPanel/ElementsTab/builder/Builder.tsx
+++ b/src/components/editMeasure/testCases/components/editTestCase/qiCore/LeftPanel/ElementsTab/builder/Builder.tsx
@@ -47,7 +47,7 @@ export const NO_PROFILES_MESSAGE =
  * Deduplicates, filters to qicore/us-core, sorts alphabetically,
  * and moves QI-Core Patient to the front of the list.
  */
-const deduplicateAndSortResources = (
+export const deduplicateAndSortResources = (
   identifiers: ResourceIdentifier[]
 ): ResourceIdentifier[] => {
   const sorted = _.uniqBy(identifiers, "profile")

--- a/src/components/editMeasure/testCases/components/editTestCase/qiCore/LeftPanel/ElementsTab/builder/Builder.tsx
+++ b/src/components/editMeasure/testCases/components/editTestCase/qiCore/LeftPanel/ElementsTab/builder/Builder.tsx
@@ -52,7 +52,8 @@ export const deduplicateAndSortResources = (
 ): ResourceIdentifier[] => {
   const sorted = _.uniqBy(identifiers, "profile")
     .filter(
-      (res) => res.id.startsWith("qicore") || res.id.startsWith("us-core")
+      (res) =>
+        res.profile.includes("/us/qicore") || res.profile.includes("/us/core")
     )
     .sort((a, b) => a.title.localeCompare(b.title));
   const patientIdx = sorted.findIndex((r) => r.id === "qicore-patient");

--- a/src/components/editMeasure/testCases/components/editTestCase/qiCore/LeftPanel/ElementsTab/builder/Builder.tsx
+++ b/src/components/editMeasure/testCases/components/editTestCase/qiCore/LeftPanel/ElementsTab/builder/Builder.tsx
@@ -43,6 +43,29 @@ import { ResourceContextProvider } from "./ResourceContext";
 export const NO_PROFILES_MESSAGE =
   "No Profiles have been added to the test case. Navigate to the Available Elements tab to add profiles.";
 
+/**
+ * Deduplicates, filters to qicore/us-core, sorts alphabetically,
+ * and moves QI-Core Patient to the front of the list.
+ */
+const deduplicateAndSortResources = (
+  identifiers: ResourceIdentifier[]
+): ResourceIdentifier[] => {
+  const sorted = _.uniqBy(identifiers, "profile")
+    .filter(
+      (res) => res.id.startsWith("qicore") || res.id.startsWith("us-core")
+    )
+    .sort((a, b) => a.title.localeCompare(b.title));
+  const patientIdx = sorted.findIndex((r) => r.id === "qicore-patient");
+  if (patientIdx > 0) {
+    return [
+      sorted[patientIdx],
+      ...sorted.slice(0, patientIdx),
+      ...sorted.slice(patientIdx + 1),
+    ];
+  }
+  return sorted;
+};
+
 interface BuilderProps {
   testCase: TestCase;
   canEdit: boolean;
@@ -168,11 +191,8 @@ const Builder = ({
             (relevantElement) => relevantElement.profile
           );
           if (!_.isEmpty(resourceIdentifiers)) {
-            // "uniq" alone does not prevent duplicates. Correct sorting.
-            const uniqueResources = _.uniqBy(
-              resourceIdentifiers,
-              "profile"
-            ).sort((a, b) => a.title.localeCompare(b.title));
+            const uniqueResources =
+              deduplicateAndSortResources(resourceIdentifiers);
 
             const filteredResources = _.isEmpty(profiles)
               ? uniqueResources
@@ -181,18 +201,7 @@ const Builder = ({
                     profiles.includes(r.profile) ||
                     "PATIENT" === r.type.toUpperCase()
                 );
-            const patientIdx = filteredResources.findIndex(
-              (r) => r.id === "qicore-patient"
-            );
-            let sortedResources = filteredResources;
-            if (patientIdx > 0) {
-              sortedResources = [
-                filteredResources[patientIdx],
-                ...filteredResources.slice(0, patientIdx),
-                ...filteredResources.slice(patientIdx + 1),
-              ];
-            }
-            setResources(sortedResources);
+            setResources(filteredResources);
           }
         })
         .finally(() => setResourcesLoading(false));
@@ -278,7 +287,9 @@ const Builder = ({
                   (res) =>
                     res.id.startsWith("qicore") || res.id.startsWith("us-core")
                 )}
-                allResourceIdentifiers={resourceIdentifiers}
+                allResourceIdentifiers={deduplicateAndSortResources(
+                  resourceIdentifiers
+                )}
                 measureId={measure?.id}
                 measureModel={measure?.model}
                 onClick={async (resourceIdentifier: ResourceIdentifier) => {

--- a/src/components/editMeasure/testCases/components/editTestCase/qiCore/LeftPanel/ElementsTab/builder/Builder.tsx
+++ b/src/components/editMeasure/testCases/components/editTestCase/qiCore/LeftPanel/ElementsTab/builder/Builder.tsx
@@ -44,6 +44,12 @@ export const NO_PROFILES_MESSAGE =
   "No Profiles have been added to the test case. Navigate to the Available Elements tab to add profiles.";
 
 /**
+ * Returns true if the resource profile belongs to qicore or us-core.
+ */
+export const isQiCoreOrUsCoreResource = (res: ResourceIdentifier): boolean =>
+  res.profile.includes("/us/qicore") || res.profile.includes("/us/core");
+
+/**
  * Deduplicates, filters to qicore/us-core, sorts alphabetically,
  * and moves QI-Core Patient to the front of the list.
  */
@@ -51,10 +57,7 @@ export const deduplicateAndSortResources = (
   identifiers: ResourceIdentifier[]
 ): ResourceIdentifier[] => {
   const sorted = _.uniqBy(identifiers, "profile")
-    .filter(
-      (res) =>
-        res.profile.includes("/us/qicore") || res.profile.includes("/us/core")
-    )
+    .filter(isQiCoreOrUsCoreResource)
     .sort((a, b) => a.title.localeCompare(b.title));
   const patientIdx = sorted.findIndex((r) => r.id === "qicore-patient");
   if (patientIdx > 0) {
@@ -284,10 +287,7 @@ const Builder = ({
               <ResourceList
                 isComposite={isComposite}
                 onInsertTCClick={onInsertTCClick}
-                resourceIdentifiers={resources.filter(
-                  (res) =>
-                    res.id.startsWith("qicore") || res.id.startsWith("us-core")
-                )}
+                resourceIdentifiers={resources.filter(isQiCoreOrUsCoreResource)}
                 allResourceIdentifiers={deduplicateAndSortResources(
                   resourceIdentifiers
                 )}

--- a/src/components/editMeasure/testCases/components/editTestCase/qiCore/LeftPanel/ElementsTab/builder/Builder.tsx
+++ b/src/components/editMeasure/testCases/components/editTestCase/qiCore/LeftPanel/ElementsTab/builder/Builder.tsx
@@ -56,9 +56,9 @@ export const isQiCoreOrUsCoreResource = (res: ResourceIdentifier): boolean =>
 export const deduplicateAndSortResources = (
   identifiers: ResourceIdentifier[]
 ): ResourceIdentifier[] => {
-  const sorted = _.uniqBy(identifiers, "profile")
-    .filter(isQiCoreOrUsCoreResource)
-    .sort((a, b) => a.title.localeCompare(b.title));
+  const sorted = _.uniqBy(identifiers, "profile").sort((a, b) =>
+    a.title.localeCompare(b.title)
+  );
   const patientIdx = sorted.findIndex((r) => r.id === "qicore-patient");
   if (patientIdx > 0) {
     return [


### PR DESCRIPTION
…sure-relevant resources

## MADiE PR

Jira Ticket: [MAT-9977](https://jira.cms.gov/browse/MAT-9977)
(Optional) Related Tickets:

### Summary
- dedup profile and resources
- for All profiles oprion, we need to display base fhir resources as well

### All Submissions
* [x] This PR has the JIRA linked.
* [x] Required tests are included.
* [x] No extemporaneous files are included (i.e Complied files or testing results).
* [x] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).
* [ ] All CDN/Web dependencies are hosted internally (i.e MADiE-Root Repo).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
