### PR TITLE
MAT-10281: Flatten value set expansions used in tc builder codes dropdowns

### DIFF
--- a/src/components/editMeasure/testCases/components/editTestCase/qiCore/LeftPanel/ElementsTab/builder/element/types/CodesComponent.test.tsx
+++ b/src/components/editMeasure/testCases/components/editTestCase/qiCore/LeftPanel/ElementsTab/builder/element/types/CodesComponent.test.tsx
@@ -39,6 +39,25 @@ const mockExpansionResponse = {
   },
 };
 
+const mockNestedExpansionResponse = {
+  expansion: {
+    contains: [
+      {
+        code: "parent",
+        display: "Parent",
+        contains: [
+          { code: "child-a", display: "Child A" },
+          {
+            code: "child-b",
+            display: "Child B",
+            contains: [{ code: "grandchild", display: "Grandchild" }],
+          },
+        ],
+      },
+    ],
+  },
+};
+
 const structureDefinitionWithExtension = {
   id: "Extension.value[x]",
   path: "Extension.value[x]",
@@ -339,6 +358,41 @@ describe("Codes Component", () => {
       const options = screen.queryAllByRole("option");
       expect(options).toHaveLength(0);
     });
+  });
+
+  it("Should flatten nested contains entries into selectable options", async () => {
+    mockedAxios.get.mockImplementation((url) => {
+      if (url.endsWith("/value-set-definition?url=" + valueSetUrl)) {
+        return Promise.resolve({ data: mockNestedExpansionResponse });
+      }
+    });
+
+    renderWithExecutionContext(
+      <ApiContextProvider value={mockConfig}>
+        <CodesComponent
+          canEdit={true}
+          label={"Gender"}
+          value={"child-a"}
+          onChange={onChangeMock}
+          fieldRequired
+          structureDefinition={structureDefinition}
+        />
+      </ApiContextProvider>
+    );
+
+    const codeSelect = screen.getByRole("combobox", { name: "Gender" });
+    userEvent.click(codeSelect);
+
+    expect(await screen.findByTestId("code-option-parent")).toBeInTheDocument();
+    expect(
+      await screen.findByTestId("code-option-child-a")
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByTestId("code-option-child-b")
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByTestId("code-option-grandchild")
+    ).toBeInTheDocument();
   });
 
   it("Should disable the input if user cannot edit", async () => {

--- a/src/components/editMeasure/testCases/components/editTestCase/qiCore/LeftPanel/ElementsTab/builder/element/types/CodesComponent.tsx
+++ b/src/components/editMeasure/testCases/components/editTestCase/qiCore/LeftPanel/ElementsTab/builder/element/types/CodesComponent.tsx
@@ -29,7 +29,7 @@ const CodesComponent = ({
   handleDeleteElement,
 }: TypeComponentProps) => {
   const measureModel = useMeasureModel();
-  const [codes, setCodes] = useState([]);
+  const [codes, setCodes] = useState<any[]>([]);
   const fhirDefinitionServiceApi = useRef(useFhirDefinitionsServiceApi());
   const terminologyService = useRef(useTerminologyServiceApi());
   const [codeValue, setCodeValue] = useState(value);
@@ -39,6 +39,13 @@ const CodesComponent = ({
   const testIdBase = name && name.includes("[") ? name : label;
   // Replace spaces with underscores to ensure a valid HTML id/data-testid
   const sanitizedId = testIdBase.replace(/\s+/g, "_");
+
+  const flattenContains = (contains: any[] = []): any[] => {
+    return contains.flatMap((concept) => [
+      concept,
+      ...flattenContains(concept?.contains || []),
+    ]);
+  };
 
   const getAndSetCodeValueFromResource = () => {
     // ["Patient", "extension[2]", "value[x]"]
@@ -74,8 +81,11 @@ const CodesComponent = ({
         if (!_.isEmpty(valueSets)) {
           valueSets.forEach((valueSet) => {
             if (valueSet?.expansion?.contains) {
+              const flattenedContains = flattenContains(
+                valueSet.expansion.contains
+              );
               setCodes((prevCodes) => {
-                const combined = [...prevCodes, ...valueSet.expansion.contains];
+                const combined = [...prevCodes, ...flattenedContains];
                 // Remove duplicates by 'code'
                 return combined.filter(
                   (item, index, self) =>
@@ -118,7 +128,7 @@ const CodesComponent = ({
               and http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1021.103 (Other or unknown or refused to answer)
             */
             if (valueSet?.expansion?.contains) {
-              setCodes(valueSet?.expansion?.contains);
+              setCodes(flattenContains(valueSet.expansion.contains));
             } else if (valueSet?.compose?.include) {
               /*
                 If the valueSet does not have an expansion, we can use the compose.include


### PR DESCRIPTION
## MADiE PR

Jira Ticket: [MAT-10281](https://jira.cms.gov/browse/MAT-10281)
(Optional) Related Tickets:

### Summary

Handle Hierarchical binding value sets used in codes dropdowns. 

### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included.
* [ ] No extemporaneous files are included (i.e Complied files or testing results).
* [ ] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).
* [ ] All CDN/Web dependencies are hosted internally (i.e MADiE-Root Repo).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
